### PR TITLE
Make httpclient dependency of H2O provided

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -51,6 +51,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>provided</scope>
+            <version>4.5.5</version>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>


### PR DESCRIPTION
The "httpclient" dependency is very popular and used
across many projects. In this case, H2O depends on it
and it conflicted with AWS dependencies when we use
H2O OpenML in Spark jobs on AWS EMR.

This way we make it provided so that it can be decided
by users.