### PR TITLE
Bump H2O Version to 3.22.1.1

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -29,7 +29,7 @@
     <description>Contains classes and logic related with the import of H2O models.</description>
 
     <properties>
-        <h2o.version>3.18.0.8</h2o.version>
+        <h2o.version>3.22.1.1</h2o.version>
     </properties>
 
     <dependencies>
@@ -65,6 +65,11 @@
         <dependency>
             <groupId>ai.h2o</groupId>
             <artifactId>h2o-core</artifactId>
+            <version>${h2o.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.h2o</groupId>
+            <artifactId>h2o-jetty-9</artifactId>
             <version>${h2o.version}</version>
         </dependency>
         <dependency>
@@ -105,6 +110,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>ai.h2o</groupId>
             <artifactId>h2o-ext-xgboost</artifactId>

--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -110,12 +110,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--<dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>-->
 
         <dependency>
             <groupId>ai.h2o</groupId>

--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -110,12 +110,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
+        <!--<dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>4.0.1</version>
             <scope>provided</scope>
-        </dependency>
+        </dependency>-->
 
         <dependency>
             <groupId>ai.h2o</groupId>


### PR DESCRIPTION
Summary:
This commit bumps H2O to version 3.22.1.1 so that we can have access to the new Isolation Forest implementation.

It also adds two new dependencies: a javax servlet, required by H2O 3.22, as well as h2o-jetty-9, also required by H2O >3.22 in an embedded scenario, according to:
https://0xdata.atlassian.net/browse/TN-13