### PR TITLE
Bump OpenML Version to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <project.source>1.8</project.source>
         <junit.version>4.12</junit.version>
         <assertj.version>3.7.0</assertj.version>
-        <openml-api.version>0.3.0</openml-api.version>
+        <openml-api.version>1.0.0</openml-api.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
         <commons-io.version>2.4</commons-io.version>


### PR DESCRIPTION
Summary:
This commit bumps the OpenML API version to 1.0.0. None of the breaking changes in this bump are applied to this repository.