### PR TITLE
PULSEDEV-26668: Support old DataRobot versions

### DIFF
--- a/openml-datarobot/pom.xml
+++ b/openml-datarobot/pom.xml
@@ -85,6 +85,12 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>1.35</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openml-datarobot/src/main/java/com/feedzai/openml/datarobot/ClassificationBinaryDataRobotModel.java
+++ b/openml-datarobot/src/main/java/com/feedzai/openml/datarobot/ClassificationBinaryDataRobotModel.java
@@ -257,14 +257,19 @@ public class ClassificationBinaryDataRobotModel implements ClassificationMLModel
      * @return A string with the values of the {@link Instance}.
      */
     private String convertInstanceToString(final Instance instance) {
-        return getSchema().getFieldSchemas()
-                .stream()
-                .map(fieldSchema -> {
-                    if (fieldSchema.getValueSchema() instanceof StringValueSchema) {
-                        return instance.getStringValue(fieldSchema.getFieldIndex());
-                    }
-                    return String.valueOf(instance.getValue(fieldSchema.getFieldIndex()));
-                })
-                .collect(Collectors.joining( "," ));
+        try {
+            return getSchema().getFieldSchemas()
+                    .stream()
+                    .map(fieldSchema -> {
+                        if (fieldSchema.getValueSchema() instanceof StringValueSchema) {
+                            return instance.getStringValue(fieldSchema.getFieldIndex());
+                        }
+                        return String.valueOf(instance.getValue(fieldSchema.getFieldIndex()));
+                    })
+                    .collect(Collectors.joining(","));
+        } catch (final Exception e) {
+            logger.warn("Could not stringify instance (that failed to score) for printing it: {}", instance, e);
+            return "Could not render instance. Probably has wrong number of features or wrong types";
+        }
     }
 }

--- a/openml-datarobot/src/main/java/com/feedzai/openml/datarobot/DataRobotModelCreator.java
+++ b/openml-datarobot/src/main/java/com/feedzai/openml/datarobot/DataRobotModelCreator.java
@@ -193,21 +193,21 @@ public class DataRobotModelCreator implements MachineLearningModelLoader<Classif
      *
      * @param predictor Predictor for the binary model generated in DataRobot.
      * @return The target values used to train the model.
-     * @throws ModelLoadingException If the binary of the model is an older non-supported DataRobot model.
      */
-    private String[] getTargetModelValues(final Predictor predictor) throws ModelLoadingException {
+    private String[] getTargetModelValues(final Predictor predictor) {
         final String targetVarField = "classLabels";
         try {
             return (String[]) FieldUtils.readField(predictor, targetVarField, true);
         } catch (final Exception e) {
             final String errorMsg = String.format(
-                    "Jar file of the DataRobot model is not supported. A possible cause is that the model might be to " +
+                    "Jar file of the DataRobot model may not be supported. A possible cause is that the model might be to " +
                             "old and a newer version is required because it lacks the \"%s\" field with the target " +
-                            "values. If that is the cause create a new project on DataRobot and train new models.",
+                            "values. Ideally, you should create a new project on DataRobot and train new models. " +
+                            "As a workaround, the load will assume the target variable values to be 0 and 1, in that order.",
                     targetVarField
             );
-            logger.error(errorMsg, e);
-            throw new ModelLoadingException(errorMsg, e);
+            logger.warn(errorMsg, e);
+            return new String[] { "0", "1" };
         }
     }
 

--- a/openml-datarobot/src/main/java/com/feedzai/openml/datarobot/DataRobotModelCreator.java
+++ b/openml-datarobot/src/main/java/com/feedzai/openml/datarobot/DataRobotModelCreator.java
@@ -31,6 +31,7 @@ import com.feedzai.openml.util.load.LoadModelUtils;
 import com.feedzai.openml.util.load.LoadSchemaUtils;
 import com.feedzai.openml.util.validate.ClassificationValidationUtils;
 import com.feedzai.openml.util.validate.ValidationUtils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -194,7 +195,8 @@ public class DataRobotModelCreator implements MachineLearningModelLoader<Classif
      * @param predictor Predictor for the binary model generated in DataRobot.
      * @return The target values used to train the model.
      */
-    private String[] getTargetModelValues(final Predictor predictor) {
+    @VisibleForTesting
+    String[] getTargetModelValues(final Predictor predictor) {
         final String targetVarField = "classLabels";
         try {
             return (String[]) FieldUtils.readField(predictor, targetVarField, true);

--- a/openml-datarobot/src/test/java/com/feedzai/openml/datarobot/DataRobotModelProviderLoadTest.java
+++ b/openml-datarobot/src/test/java/com/feedzai/openml/datarobot/DataRobotModelProviderLoadTest.java
@@ -17,6 +17,7 @@
 
 package com.feedzai.openml.datarobot;
 
+import com.datarobot.prediction.Predictor;
 import com.feedzai.openml.data.schema.CategoricalValueSchema;
 import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.data.schema.FieldSchema;
@@ -28,6 +29,7 @@ import com.feedzai.openml.provider.descriptor.fieldtype.ParamValidationError;
 import com.feedzai.openml.provider.exception.ModelLoadingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import mockit.Mocked;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -349,5 +351,19 @@ public class DataRobotModelProviderLoadTest extends AbstractDataRobotModelProvid
                 .as("The expected error during scoring")
                 .hasMessageContaining("failed to classify")
                 .hasMessageContaining(String.valueOf(mockedValue));
+    }
+
+    /**
+     * Tests that fetching the labels from a model that does not contain them yields a default value.
+     *
+     * @param mockedPredictor The mocked predictor.
+     *
+     * @since 0.5.8
+     */
+    @Test
+    public void readUnexistingTargetLabelsTest(final @Mocked Predictor mockedPredictor) {
+        assertThat(new DataRobotModelCreator().getTargetModelValues(mockedPredictor))
+                .as("The target labels")
+                .containsExactlyInAnyOrder("0", "1");
     }
 }


### PR DESCRIPTION
Our DataRobot provider was assuming that Jar files contained a "classLabels" field
in the Model class, which would describe the possible target values for the target
variable being predicted.

That is not the case for old DataRobot versions. As DataRobot supports only binary
classification in exported Jars, we thus assume that the values are "0" and "1" in
that order --- i.e., the positive class is the second one, as is typical on binary
classification problems.