### PR TITLE
openml-datarobot: Remove javafx dependency

### DIFF
--- a/openml-datarobot/src/main/java/com/feedzai/openml/datarobot/DataRobotModelCreator.java
+++ b/openml-datarobot/src/main/java/com/feedzai/openml/datarobot/DataRobotModelCreator.java
@@ -35,9 +35,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import javafx.util.Pair;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -179,7 +179,7 @@ public class DataRobotModelCreator implements MachineLearningModelLoader<Classif
                 modelFilePath,
                 ClassificationBinaryDataRobotModel.class.getClassLoader()
         );
-        return new Pair<>(
+        return Pair.of(
                 (Predictor) JavaFileUtils.createNewInstanceFromClassLoader(
                         modelFilePath,
                         MODEL_PACKAGE_TEMPLATE,


### PR DESCRIPTION
Summary:
Use were using the javafx Pair util class, which seems a bit overkill, since we were dependending on javafx just for this. Furthermore, javafx is not
a default java library for all environments, so environments which do not have javafx will fail when using this logic.

The javafx Pair class was replaced by the apache commons lang3 version, which does everything we want, and was already a dependency of our project.