### PR TITLE
fix PULSEDEV-27633 openml-h2o: Adds more information in case of error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Feedzai OpenML Providers for Java
-[![Build Status](https://travis-ci.com/feedzai/feedzai-openml-java.svg?branch=hf-1.0.X)](https://travis-ci.com/feedzai/feedzai-openml-java)
-[![codecov](https://codecov.io/gh/feedzai/feedzai-openml-java/branch/hf-1.0.X/graph/badge.svg)](https://codecov.io/gh/feedzai/feedzai-openml-java)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/4d92197f37ab4811b81f34bd4847fee6?branch=hf-1.0.X)](https://www.codacy.com/app/feedzai/feedzai-openml-java?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=feedzai/feedzai-openml-java&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://travis-ci.com/feedzai/feedzai-openml-java.svg?branch=master)](https://travis-ci.com/feedzai/feedzai-openml-java)
+[![codecov](https://codecov.io/gh/feedzai/feedzai-openml-java/branch/master/graph/badge.svg)](https://codecov.io/gh/feedzai/feedzai-openml-java)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/4d92197f37ab4811b81f34bd4847fee6?branch=master)](https://www.codacy.com/app/feedzai/feedzai-openml-java?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=feedzai/feedzai-openml-java&amp;utm_campaign=Badge_Grade)
 
 Implementations of the Feedzai OpenML API to allow support for machine
 learning models in Java. 
@@ -26,7 +26,7 @@ Pull the provider from Maven Central:
   <groupId>com.feedzai</groupId>
   <artifactId>openml-h2o</artifactId>
   <!-- See project tags for latest version -->
-  <version>1.0.0</version>
+  <version>1.0.2</version>
 </dependency>
 ```
 
@@ -41,6 +41,6 @@ Pull this module from Maven Central:
   <groupId>com.feedzai</groupId>
   <artifactId>openml-datarobot</artifactId>
   <!-- See project tags for latest version -->
-  <version>1.0.0</version>
+  <version>1.0.2</version>
 </dependency>
 ```

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/server/H2OApp.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/server/H2OApp.java
@@ -49,6 +49,7 @@ import hex.tree.gbm.GBM;
 import hex.tree.isofor.IsolationForest;
 import hex.tree.isofor.IsolationForestModel;
 import hex.tree.xgboost.XGBoost;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import water.ExtensionManager;
@@ -322,11 +323,19 @@ public class H2OApp<M extends Model> {
      * @param dataSetFile DataSet filename.
      * @param schema The {@link DatasetSchema}-
      * @return Frame or NPE.
+     * @throws ModelTrainingException if the dataset file is empty
      *
      * @implNote This method needs to be synchronized. While we can't really pinpoint the exact reason, the experience
      * with tests training multiple models concurrently shows that this method is not thread safe.
      */
-    private synchronized Frame parseDataSetFile(final Path dataSetFile, final DatasetSchema schema) {
+    private synchronized Frame parseDataSetFile(final Path dataSetFile,
+                                                final DatasetSchema schema) throws ModelTrainingException{
+        if (FileUtils.sizeOf(dataSetFile.toFile()) == 0) {
+            logger.info("The file: {} is empty. Cannot generate the model.", dataSetFile);
+            throw new ModelTrainingException(
+                    String.format("In order to generate the model the dataset cannot be empty. File: %s is empty.", dataSetFile));
+        }
+
         final NFSFileVec nfs = NFSFileVec.make(dataSetFile.toFile());
 
         final ParseSetup userSetup = new ParseSetup();

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
@@ -28,6 +28,7 @@ import com.feedzai.openml.util.provider.AbstractProviderModelTrainTest;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.internal.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +43,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 
 /**
  * Tests for training models with {@link H2OModelProvider}.
@@ -228,4 +230,19 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
                 .doesNotThrowAnyException();
     }
 
+    /**
+     * Tests that the right exception is thrown when the dataset is empty
+     * @since 1.0.9
+     */
+    @Test
+    public final void testExceptionIsThrownWhenDatasetIsEmpty() {
+        final Dataset dataset = createDataset(SCHEMA, 0);
+        final Map<String, String> params = H2OAlgorithmTestParams.getIsolationForest();
+        final H2OModelCreator loader = getMachineLearningModelLoader(H2OAlgorithm.ISOLATION_FOREST);
+        final Random random = new Random(234);
+        final Throwable thrown = catchThrowable(() -> loader.fit(dataset, random, params));
+
+        assertThat(thrown).isInstanceOf(ModelTrainingException.class)
+                          .hasMessageContaining("In order to generate the model the dataset cannot be empty");
+    }
 }


### PR DESCRIPTION
An additional check was added to verify that the dataset that was
written to disk is not empty, that would cause an error later inside the
h2o code.