### PR TITLE
Remove underperforming native libraries

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -230,6 +230,7 @@
                                         <exclude>org/slf4j/**</exclude>
                                         <exclude>com/esotericsoftware/kryo/**</exclude>
                                         <exclude>org/objenesis/**</exclude>
+                                        <!-- The following two libraries were removed because they were under-performing in cluster environments-->
                                         <exclude>**/libxgboost4j_gpu.so</exclude>
                                         <exclude>**/libxgboost4j_omp.so</exclude>
                                     </excludes>

--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -231,7 +231,7 @@
                                         <exclude>com/esotericsoftware/kryo/**</exclude>
                                         <exclude>org/objenesis/**</exclude>
                                         <exclude>**/libxgboost4j_gpu.so</exclude>
-					<exclude>**/libxgboost4j_omp.so</exclude>
+                                        <exclude>**/libxgboost4j_omp.so</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -230,6 +230,8 @@
                                         <exclude>org/slf4j/**</exclude>
                                         <exclude>com/esotericsoftware/kryo/**</exclude>
                                         <exclude>org/objenesis/**</exclude>
+                                        <exclude>**/libxgboost4j_gpu.so</exclude>
+					<exclude>**/libxgboost4j_omp.so</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
After analysing the behaviour of the H2O XGBoost algorithm behaviour
while evaluation in some environments, such as Spark Clusters, it was
clear that it was taking too long to perform the model evaluations.

To temporarly fix this problems it was recommended to perform the
evaluations locally, which, for some reason, were much faster.

After some tests in all environments we found that the difference
between the environments was the native backend library that was
being loaded during the XGBoost initialization.

While the local machines were using the `xgboost4j_minimal` native
library, the Cloudera machines were using the `xgboost4j_gpu`.

This alone made the evaluations take around 100x more time to complete.

After removing the native library from the JAR the evaluations
start performing almost the same independent of the environment.

After testing this in a real environment the evaluation time went down
from 2 hours to only 8 minutes to evaluate the same dataset with the same
model.

The `xgboost4j_omp` was also removed because the `xgboost4j_minimal`
was the one that was loaded everywhere without problem. The loading
queue is: try to load `xgboost4j_gpu`, if not possible, `xgboost4j_omp`
and only if that is also not possible, the `xgboost4j_minimal`.

The one that was kept was able to be loaded in all tested environments:
Local machine with Ubuntu 18.04, Cloudera Container and Amazon EMR.