### PR TITLE
fix PULSEDEV-31040 openml-h20: Parse Deep Learning model parameter hi…

### DIFF
--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODeepLearningUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODeepLearningUtils.java
@@ -21,6 +21,7 @@ import com.feedzai.openml.h2o.params.ParametersBuilderUtil;
 import com.feedzai.openml.h2o.params.ParamsValueSetter;
 import com.feedzai.openml.provider.descriptor.ModelParameter;
 import hex.schemas.DeepLearningV3.DeepLearningParametersV3;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.Set;
@@ -63,7 +64,7 @@ public final class H2ODeepLearningUtils extends AbstractSupervisedH2OParamUtils<
 
             if (HIDDEN.equals(paramName)) {
                 cleanParam(params.get(HIDDEN)).ifPresent(param ->
-                        h2oParams.hidden = Stream.of(param.split(LIST_PARAM_DELIMITER)).mapToInt(Integer::parseInt).toArray()
+                        h2oParams.hidden = Stream.of(StringUtils.strip(param, "[]").split(LIST_PARAM_DELIMITER)).mapToInt(Integer::parseInt).toArray()
                 );
                 return;
             }


### PR DESCRIPTION
fix PULSEDEV-31040 openml-h20: Parse Deep Learning model parameter hidden when using array format

When training a H20 Deep learning model, if the default value for the parameter
"Hidden" is used "[200,200]" or another value that follows the format of the
hint "[100,100]" the job will crash.

This happens because when this parameter is parsed the value is assumed to be
in a different format, that doesn't contain square brackets at the beginning
and end of the list of integers e.g. "200,200".

To fix this, when parsing the value, if present the square brackets are removed
from the beginning and the end of the string.