### PR TITLE
Prepare code for more recent versions of Guava

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -51,6 +51,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!--Guava-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/openml-java-utils/pom.xml
+++ b/openml-java-utils/pom.xml
@@ -46,6 +46,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!--Guava-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,15 @@
                 <version>1.0-rc2</version>
             </dependency>
 
+            <!-- Use the same dependencies versions of openml-api -->
+            <dependency>
+                <groupId>com.feedzai</groupId>
+                <artifactId>openml</artifactId>
+                <version>${openml-api.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
             <!--Apache commons-->
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
While upgrading guava to version 29-jre some methods where removed. Since we can't release a version with guava upgraded yet we can already remove the use of deprecated methods, and replace it with similar methods.