### PR TITLE
LightGBM: Restore visibility modifiers.

### DIFF
--- a/openml-lightgbm/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMDescriptorUtil.java
+++ b/openml-lightgbm/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMDescriptorUtil.java
@@ -92,8 +92,8 @@ public class LightGBMDescriptorUtil {
      * @return Double range with the specs above.
      */
     private static final NumericFieldType doubleRange(final double minValue,
-                                               final double maxValue,
-                                               final double defaultValue) {
+                                                      final double maxValue,
+                                                      final double defaultValue) {
         return NumericFieldType.range(minValue, maxValue, NumericFieldType.ParameterConfigType.DOUBLE, defaultValue);
     }
 

--- a/openml-lightgbm/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
+++ b/openml-lightgbm/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
@@ -74,7 +74,7 @@ class SWIGResources implements AutoCloseable {
      * Whilst not a swig resource, it is automatically retrieved during model loading,
      * thus we store it to avoid calling it again.
      */
-    Integer boosterNumIterations;
+    private Integer boosterNumIterations;
 
     /**
      * Constructor. Initializes a model handle and all resource handlers

--- a/openml-lightgbm/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGTrainResources.java
+++ b/openml-lightgbm/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGTrainResources.java
@@ -44,7 +44,7 @@ public class SWIGTrainResources implements AutoCloseable {
     /**
      * Handle for the output parameter necessary for the LightGBM dataset instantiation.
      */
-    public SWIGTYPE_p_p_void swigOutDatasetHandlePtr;
+    SWIGTYPE_p_p_void swigOutDatasetHandlePtr;
 
     /**
      * SWIG pointer to the Features data array.
@@ -53,27 +53,27 @@ public class SWIGTrainResources implements AutoCloseable {
      * In the current implementation, features are stored in row-major order, i.e.,
      * each instance is stored contiguously.
      */
-    public SWIGTYPE_p_double swigTrainFeaturesDataArray;
+    SWIGTYPE_p_double swigTrainFeaturesDataArray;
 
     /**
      * SWIG pointer to the labels array (array of float32 elements).
      */
-    public SWIGTYPE_p_float swigTrainLabelDataArray;
+    SWIGTYPE_p_float swigTrainLabelDataArray;
 
     /**
      * SWIG LightGBM dataset handle.
      */
-    public SWIGTYPE_p_void swigDatasetHandle;
+    SWIGTYPE_p_void swigDatasetHandle;
 
     /**
      * SWIG pointer to the output LightGBM Booster Handle during Booster structure instantiation.
      */
-    public SWIGTYPE_p_p_void swigOutBoosterHandlePtr;
+    SWIGTYPE_p_p_void swigOutBoosterHandlePtr;
 
     /**
      * Handle of the LightGBM boosting model post-instantiation.
      */
-    public SWIGTYPE_p_void swigBoosterHandle;
+    SWIGTYPE_p_void swigBoosterHandle;
 
     /**
      * Constructor.
@@ -103,14 +103,14 @@ public class SWIGTrainResources implements AutoCloseable {
     /**
      * Setup swigDatasetHandle after its setup.
      */
-    public void initSwigDatasetHandle() {
+    void initSwigDatasetHandle() {
         this.swigDatasetHandle = lightgbmlib.voidpp_value(this.swigOutDatasetHandlePtr);
     }
 
     /**
      * Setup swigBoosterHandle after its structure was created in-memory.
      */
-    public void initSwigBoosterHandle() {
+    void initSwigBoosterHandle() {
         this.swigBoosterHandle = lightgbmlib.voidpp_value(this.swigOutBoosterHandlePtr);
     }
 
@@ -118,7 +118,7 @@ public class SWIGTrainResources implements AutoCloseable {
      * Release the memory of the label array.
      * This can be called after instantiating the dataset and setting the label in it.
      */
-    public void destroySwigTrainLabelDataArray() {
+    void destroySwigTrainLabelDataArray() {
 
         if (this.swigTrainLabelDataArray != null) {
             lightgbmlib.delete_floatArray(this.swigTrainLabelDataArray);
@@ -130,7 +130,7 @@ public class SWIGTrainResources implements AutoCloseable {
      * Release the memory of the features array.
      * This can be called after instantiating the dataset.
      */
-    public void destroySwigTrainFeaturesDataArray() {
+    void destroySwigTrainFeaturesDataArray() {
 
         if (this.swigTrainFeaturesDataArray != null) {
             lightgbmlib.delete_doubleArray(this.swigTrainFeaturesDataArray);
@@ -142,7 +142,7 @@ public class SWIGTrainResources implements AutoCloseable {
      * Release any allocated resources.
      * This operation is idempotent and can be safely called at any time as many times as you wish.
      */
-    public void releaseResources() {
+    void releaseResources() {
 
         if (this.swigOutDatasetHandlePtr != null) {
             lightgbmlib.delete_voidpp(this.swigOutDatasetHandlePtr);

--- a/openml-lightgbm/src/test/java/com/feedzai/openml/provider/lightgbm/TestSchemas.java
+++ b/openml-lightgbm/src/test/java/com/feedzai/openml/provider/lightgbm/TestSchemas.java
@@ -107,7 +107,7 @@ public class TestSchemas {
      * "uuid","cat1_generator","cat2_generator","cat3_generator","num1_float","num2_double","num3_int",
      * "cat1_string","cat2_string","cat3_string"
      */
-    static final DatasetSchema CATEGORICALS_SCHEMA_LABEL_AT_END = new DatasetSchema(
+    public static final DatasetSchema CATEGORICALS_SCHEMA_LABEL_AT_END = new DatasetSchema(
             7,
             ImmutableList.<FieldSchema>builder()
                     .addAll(CATEGORICAL_SCHEMA_FEATURES)


### PR DESCRIPTION
Some visibility modifiers were introduced with the port.

This restores the visibility modifiers where appropriate.
This is mainly in the source code, but also includes one of the test schemas that was used for AutoML.