### PR TITLE
Add exec maven plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,11 @@
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.1.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
Due to this [release issue](https://github.com/feedzai/feedzai-openml-java/issues/33) I'm adding the exec maven plugin version.
I hope that this may fix the problem.

Note: I removed the tag and release regarding 1.0.10 and 1.0.11 because it wasn't published to the [feedzai maven](https://maven.feedzai.com/#nexus-search;gavcom.feedzaiopenml-java~~~~kw,versionexpand) neither [maven central](https://mvnrepository.com/artifact/com.feedzai/openml-java-utils).