### PR TITLE
Fix LightGBM lib deploy plugin

### DIFF
--- a/openml-lightgbm-meta-module/lightgbm-builder/pom.xml
+++ b/openml-lightgbm-meta-module/lightgbm-builder/pom.xml
@@ -74,15 +74,8 @@
 
             <!-- Deploy lightgbmlib.jar + .pom -->
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
-                </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>deploy-custom-lightgbmlib_build</id>
@@ -93,6 +86,7 @@
                         <configuration>
                             <file>${project.basedir}/make-lightgbm/build/lightgbmlib.jar</file>
                             <pomFile>${project.basedir}/make-lightgbm/build/pom.xml</pomFile>
+                            <generatePom>false</generatePom>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Previously [nexus-staging-maven-plugin](https://javalibs.com/plugin/org.sonatype.plugins/nexus-staging-maven-plugin) was used to deploy LightGBM lib. However, it doesn't provide deploy-file goal as shown in the end of this [error message](https://api.travis-ci.com/v3/job/371422084/log.txt).

Since we already have installed it using maven-install-plugin, this commit changes nexus-staging-maven-plugin to maven-deploy-plugin.