### PR TITLE
Update lightgbm-lib pom and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Pull the provider from Maven Central:
   <groupId>com.feedzai</groupId>
   <artifactId>openml-h2o</artifactId>
   <!-- See project tags for latest version -->
-  <version>1.0.13</version>
+  <version>1.0.14</version>
 </dependency>
 ```
 
@@ -41,7 +41,7 @@ Pull this module from Maven Central:
   <groupId>com.feedzai</groupId>
   <artifactId>openml-datarobot</artifactId>
   <!-- See project tags for latest version -->
-  <version>1.0.13</version>
+  <version>1.0.14</version>
 </dependency>
 ```
 
@@ -56,6 +56,6 @@ Pull this module from Maven Central:
   <groupId>com.feedzai</groupId>
   <artifactId>openml-lightgbm</artifactId>
   <!-- See project tags for latest version -->
-  <version>1.0.13</version>
+  <version>1.0.14</version>
 </dependency>
 ```

--- a/openml-lightgbm-module/lightgbm-lib/pom.xml
+++ b/openml-lightgbm-module/lightgbm-lib/pom.xml
@@ -26,57 +26,6 @@
         <lightgbmlib.version>2.3.190</lightgbmlib.version>
     </properties>
 
-    <!-- jgitver changes the version 2.3.190 to project version, therefore we excluded this project from jgitver -->
-    <!-- for this reason we can't use parent on this module, so I'm repeating this profile from root pom -->
-    <profiles>
-        <profile>
-            <id>release</id>
-            <properties>
-                <gpg.executable>gpg</gpg.executable>
-                <gpg.keyname>${env.PGP_KEY_ID}</gpg.keyname>
-                <gpg.passphrase>${env.PGP_PASS}</gpg.passphrase>
-                <gpg.defaultKeyring>false</gpg.defaultKeyring>
-                <gpg.homedir>${user.dir}/.gnupg</gpg.homedir>
-            </properties>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.4</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <build>
         <resources>
             <resource>
@@ -140,13 +89,9 @@
                     </execution>
                 </executions>
             </plugin>
-
-
-
         </plugins>
     </build>
-
-
+    
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>


### PR DESCRIPTION
As shown on [this error messaging](https://travis-ci.com/github/feedzai/feedzai-openml-java/builds/180705248) it failed to create a tag due to deploying lightgbm-lib problem.
Therefore this change removes nexus-staging-maven-plugin on lightgbm-lib. It is also because we already declared it as provided in the dependency scope.