### PR TITLE
Add H2O GLM mandatory properties with default values for tests

### DIFF
--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
@@ -134,6 +134,9 @@ public final class H2OAlgorithmTestParams {
                 .put("standardize", "true")
                 .put("non_negative", "true")
                 .put("obj_reg", "-1")
+                .put("theta", "1e-10")
+                .put("HGLM", "false")
+                .put("calc_like", "false")
                 .build();
 
     }

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
@@ -134,9 +134,9 @@ public final class H2OAlgorithmTestParams {
                 .put("standardize", "true")
                 .put("non_negative", "true")
                 .put("obj_reg", "-1")
-                .put("theta", "1e-10")
-                .put("HGLM", "false")
-                .put("calc_like", "false")
+                .put("theta", "1e-10")      // default value
+                .put("HGLM", "false")       // default value
+                .put("calc_like", "false")  // default value
                 .build();
 
     }
@@ -150,6 +150,10 @@ public final class H2OAlgorithmTestParams {
         return ImmutableMap.<String, String>builder()
                 .put("ntrees", "100")
                 .put("sample_size", "100")
+                .put("mtries", "-1")        // default value
+                .put("sample_rate", "-1")   // default value
+                .put("max_depth", "8")      // default value
+                .put("min_rows", "1")       // default value
                 .build();
     }
 }

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
@@ -251,7 +251,14 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
      */
     @Test
     public final void ensureH2OAlgorithmsHaveMandatoryParams() {
-        this.getTrainAlgorithms().forEach(
+
+        final Map<MLAlgorithmEnum, Map<String, String>> trainAlgorithms = this.getTrainAlgorithms();
+
+        assertThat(trainAlgorithms.size())
+                .as("The list of training algorithms must not be null.")
+                .isNotEqualTo(0);
+
+        trainAlgorithms.forEach(
                 (algorithm, params) -> validateParamsForTheAlgorithm(params, algorithm)
         );
     }
@@ -276,6 +283,8 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
                 params
         );
 
-        assertThat(paramValidationErrors.size()).isEqualTo(0);
+        assertThat(paramValidationErrors.size())
+                .as("The list parameter validation errors must be null.")
+                .isEqualTo(0);
     }
 }

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
@@ -253,7 +253,9 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
     @Test
     public final void ensureH2OAlgorithmsHaveMandatoryParams() {
         this.getTrainAlgorithms().forEach(
-                (algorithm, params) -> validateParamsForAlgorithms(params, algorithm)
+                (algorithm, params) -> {
+                    assertThat(validateParamsForAlgorithms(params, algorithm).size()).isEqualTo(0);
+                }
         );
     }
 
@@ -262,9 +264,11 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
      *
      * @param params    The default parameters.
      * @param algorithm The H2O algorithm.
+     *
+     * @return The list of Parameter Validation Errors.
      * @since 1.0.18
      */
-    private void validateParamsForAlgorithms(final Map<String, String> params, final MLAlgorithmEnum algorithm) {
+    private List<ParamValidationError> validateParamsForAlgorithms(final Map<String, String> params, final MLAlgorithmEnum algorithm) {
 
         final H2OModelCreator loader = getMachineLearningModelLoader(algorithm);
 
@@ -277,6 +281,6 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
                 params
         );
 
-        assertThat(paramValidationErrors.size()).isEqualTo(0);
+        return paramValidationErrors;
     }
 }

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
@@ -32,7 +32,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import water.H2O;
 
 import java.io.File;
 import java.util.List;
@@ -253,9 +252,7 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
     @Test
     public final void ensureH2OAlgorithmsHaveMandatoryParams() {
         this.getTrainAlgorithms().forEach(
-                (algorithm, params) -> {
-                    assertThat(validateParamsForAlgorithms(params, algorithm).size()).isEqualTo(0);
-                }
+                (algorithm, params) -> validateParamsForTheAlgorithm(params, algorithm)
         );
     }
 
@@ -264,11 +261,9 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
      *
      * @param params    The default parameters.
      * @param algorithm The H2O algorithm.
-     *
-     * @return The list of Parameter Validation Errors.
      * @since 1.0.18
      */
-    private List<ParamValidationError> validateParamsForAlgorithms(final Map<String, String> params, final MLAlgorithmEnum algorithm) {
+    private void validateParamsForTheAlgorithm(final Map<String, String> params, final MLAlgorithmEnum algorithm) {
 
         final H2OModelCreator loader = getMachineLearningModelLoader(algorithm);
 
@@ -281,6 +276,6 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
                 params
         );
 
-        return paramValidationErrors;
+        assertThat(paramValidationErrors.size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
There are three mandatory parameters that [H2O GLM 3.22.1.X](http://h2o-release.s3.amazonaws.com/h2o/rel-xu/3/docs-website/h2o-docs/data-science/glm.html) doesn't use and [H2O GLM 3.30.0.X](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/glm.html) does:

* theta
* HGLM
* calc_like

This commit adds these three parameters with its default values.

Added UT to ensure that all algorithms have the mandatory parameters

With the above UT, we discover that there are four mandatory parameters that [H2O Isolation Forest 3.22.1.X](http://h2o-release.s3.amazonaws.com/h2o/rel-xu/3/docs-website/h2o-docs/data-science/if.html) already provided and we didn't add it.

* mtries
* sample_rate
* max_depth
* min_rows

This commit also adds these four parameters with its default values.