### PR TITLE
LightGBM: Upgrade to v3.0.0 and support UTF-8 feature names

### DIFF
--- a/openml-lightgbm/lightgbm-builder/pom.xml
+++ b/openml-lightgbm/lightgbm-builder/pom.xml
@@ -31,7 +31,7 @@
         LIGHTGBM_REPO_URL=https://github.com/microsoft/LightGBM
         LIGHTGBM_VERSION=v3.0.0
         LIGHTGBM_COMMIT=7e11d4aeabd4a39ffa4afb382299c6d00ddf01e7
-        PACKAGE_TIMESTAMP=20/09/01 18:20:49
+        PACKAGE_TIMESTAMP=2020/09/01 18:20:49
     </description>
     <url>https://github.com/feedzai/make-lightgbm</url>
 

--- a/openml-lightgbm/lightgbm-builder/pom.xml
+++ b/openml-lightgbm/lightgbm-builder/pom.xml
@@ -15,30 +15,30 @@
 
     <groupId>com.feedzai.openml.lightgbm</groupId>
     <artifactId>lightgbm-lib</artifactId>
-    <version>2.3.190</version>
+    <version>3.0.0</version>
 
     <packaging>jar</packaging>
     <name>Openml LightGBM lib</name>
     <description>
         LightGBM build for Java generated with make-lightgbm.
 
-        Build created with command: `bash make.sh fc79b366153e8aa5cf2996b4b753e28e5a75e878 2.3.190`
+        Build created with command: `bash make.sh v3.0.0 3.0.0`
 
         ---
 
         Build info:
 
         LIGHTGBM_REPO_URL=https://github.com/microsoft/LightGBM
-        LIGHTGBM_VERSION=fc79b366153e8aa5cf2996b4b753e28e5a75e878
-        LIGHTGBM_COMMIT=fc79b366153e8aa5cf2996b4b753e28e5a75e878
-        PACKAGE_TIMESTAMP=20/08/21 07:43:12
+        LIGHTGBM_VERSION=v3.0.0
+        LIGHTGBM_COMMIT=7e11d4aeabd4a39ffa4afb382299c6d00ddf01e7
+        PACKAGE_TIMESTAMP=20/09/01 18:20:49
     </description>
     <url>https://github.com/feedzai/make-lightgbm</url>
 
     <properties>
         <lightgbm.repo.url>https://github.com/microsoft/LightGBM</lightgbm.repo.url>
-        <lightgbm.version>fc79b366153e8aa5cf2996b4b753e28e5a75e878</lightgbm.version>
-        <lightgbmlib.version>2.3.190</lightgbmlib.version>
+        <lightgbm.version>v3.0.0</lightgbm.version>
+        <lightgbmlib.version>3.0.0</lightgbmlib.version>
     </properties>
 
     <!-- jgitver changes the version 2.3.190 to project version, therefore we excluded this project from jgitver -->

--- a/openml-lightgbm/lightgbm-provider/pom.xml
+++ b/openml-lightgbm/lightgbm-provider/pom.xml
@@ -25,7 +25,7 @@
     <description>OpenML Microsoft LightGBM Machine Learning Model and Classifier provider</description>
 
     <properties>
-        <lightgbmlib.version>2.3.190</lightgbmlib.version>
+        <lightgbmlib.version>3.0.0</lightgbmlib.version>
     </properties>
 
     <dependencies>

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainer.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainer.java
@@ -217,8 +217,8 @@ final class LightGBMBinaryClassificationModelTrainer {
      * @param numInstances            Number of instances in dataset.
      */
     private static void setLightGBMDatasetLabelData(final SWIGTYPE_p_void swigDatasetHandle,
-                                            final SWIGTYPE_p_float swigTrainLabelDataArray,
-                                            final int numInstances) {
+                                                    final SWIGTYPE_p_float swigTrainLabelDataArray,
+                                                    final int numInstances) {
 
         logger.debug("Setting label data.");
         final int returnCodeLGBM = lightgbmlib.LGBM_DatasetSetField(

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
@@ -151,6 +151,7 @@ class LightGBMSWIG {
                     this.schemaNumFeatures,
                     isRowMajor,
                     lightgbmlibConstants.C_API_PREDICT_NORMAL,
+                    0, // start at iteration 0
                     numIterations,
                     LightGBMParameters,
                     // useless API output: size known already (had to preallocate memory)

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainerTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainerTest.java
@@ -223,7 +223,7 @@ public class LightGBMBinaryClassificationModelTrainerTest {
      * Assert that non-ASCII feature names can be used for train.
      */
     @Test
-    public void fitWithASCIIFeatureNameIsOKTest () {
+    public void fitWithNonASCIIFeatureNameIsPossible () {
 
         final Dataset dataset = new MockDataset(
                 TestSchemas.SCHEMA_WITH_TWO_NON_ASCII_FEATURES, 10, new Random());

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainerTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainerTest.java
@@ -219,6 +219,25 @@ public class LightGBMBinaryClassificationModelTrainerTest {
                 .isEqualTo(1);
     }
 
+    /**
+     * Assert that non-ASCII feature names can be used for train.
+     */
+    @Test
+    public void fitWithASCIIFeatureNameIsOKTest () {
+
+        final Dataset dataset = new MockDataset(
+                TestSchemas.SCHEMA_WITH_TWO_NON_ASCII_FEATURES, 10, new Random());
+        final Map<String, String> trainParams = new HashMap<>(modelParams);
+
+        final LightGBMBinaryClassificationModel model = new LightGBMModelCreator().fit(
+                dataset,
+                new Random(),
+                trainParams
+        );
+
+        assertThat(model.getClassDistribution(dataset.instance(0))[1]).as("score")
+                .isBetween(0.0, 1.0);
+    }
 
     /**
      * With a dataset and schema choice, fit a model and evaluate it on part or the full data.

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMModelCreatorTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMModelCreatorTest.java
@@ -66,7 +66,7 @@ public class LightGBMModelCreatorTest {
     /**
      * No parameters to pass for now.
      */
-    private final Map<String, String> params = new HashMap<String, String>();
+    private final Map<String, String> params = new HashMap<>();
 
     /**
      * Prepares the tests.
@@ -94,12 +94,11 @@ public class LightGBMModelCreatorTest {
     @Test
     public void loadModelFailsOnNonModelResourceLoadTest() {
 
-        assertThatExceptionOfType(ModelLoadingException.class).isThrownBy(() -> {
+        assertThatExceptionOfType(ModelLoadingException.class).isThrownBy(() ->
             modelLoader.loadModel(
                     TestResources.getScoredInstancesPath(), // Shouldn't be able to load a non-LightGBM file as a model.
                     TestSchemas.NUMERICALS_SCHEMA_WITH_LABEL_AT_END
-            );
-        });
+            ));
 
     }
 
@@ -277,12 +276,12 @@ public class LightGBMModelCreatorTest {
     @Test
     public void loadModelWithWrongNumberOfFieldsThrowsTest() {
 
-        assertThatExceptionOfType(ModelLoadingException.class).isThrownBy(() -> {
+        assertThatExceptionOfType(ModelLoadingException.class).isThrownBy(() ->
             modelLoader.loadModel(
                     TestResources.getModelFilePath(),
                     TestSchemas.BAD_NUMERICALS_SCHEMA_WITH_MISSING_FIELDS
-            );
-        }).withMessage(ERROR_MSG_SCHEMA_WITH_WRONG_PREDICTIVE_FIELDS_SIZE);
+            )
+        ).withMessage(ERROR_MSG_SCHEMA_WITH_WRONG_PREDICTIVE_FIELDS_SIZE);
     }
 
     /**
@@ -293,12 +292,12 @@ public class LightGBMModelCreatorTest {
     @Test
     public void loadModelFolderDoesNotThrowTest() {
 
-        assertThatCode(() -> {
+        assertThatCode(() ->
             modelLoader.loadModel(
                     TestResources.getModelFolderPath(),
                     TestSchemas.NUMERICALS_SCHEMA_WITH_LABEL_AT_END
-            );
-        }).doesNotThrowAnyException();
+            )
+        ).doesNotThrowAnyException();
     }
 
     /**
@@ -307,12 +306,12 @@ public class LightGBMModelCreatorTest {
     @Test
     public void loadModelFileDoesNotThrowTest() {
 
-        assertThatCode(() -> {
+        assertThatCode(() ->
             modelLoader.loadModel(
                     TestResources.getModelFilePath(),
                     TestSchemas.NUMERICALS_SCHEMA_WITH_LABEL_AT_END
-            );
-        }).doesNotThrowAnyException();
+            )
+        ).doesNotThrowAnyException();
     }
 
     /**

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestSchemas.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestSchemas.java
@@ -202,4 +202,18 @@ public class TestSchemas {
             0,
             TestSchemas.NUMERICALS_SCHEMA_WITH_LABEL_AT_END.getPredictiveFields()
     );
+
+    /**
+     * Schema with two features with non-ASCII characters.
+     */
+    static final DatasetSchema SCHEMA_WITH_TWO_NON_ASCII_FEATURES = new DatasetSchema(
+            0,
+            ImmutableList.<FieldSchema>builder()
+                    .addAll(NUMERICALS_SCHEMA_WITH_TARGET_AT_START.getFieldSchemas())
+                    .add(new FieldSchema("cão", 5,
+                            new NumericValueSchema(false)))
+                    .add(new FieldSchema("test \uD801\uDC00", 6,
+                            new NumericValueSchema(false)))
+                    .build()
+    );
 }

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestSchemas.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestSchemas.java
@@ -210,10 +210,8 @@ public class TestSchemas {
             0,
             ImmutableList.<FieldSchema>builder()
                     .addAll(NUMERICALS_SCHEMA_WITH_TARGET_AT_START.getFieldSchemas())
-                    .add(new FieldSchema("cão", 5,
-                            new NumericValueSchema(false)))
-                    .add(new FieldSchema("test \uD801\uDC00", 6,
-                            new NumericValueSchema(false)))
+                    .add(new FieldSchema("cão", 5, new NumericValueSchema(false)))
+                    .add(new FieldSchema("test \uD801\uDC00", 6, new NumericValueSchema(false)))
                     .build()
     );
 }


### PR DESCRIPTION
* Upgrade to LightGBM v3.0.0
* The just released v3.0.0 allows UTF-8 feature names
* Change scoring code to support new prediction API
  * Works correctly: wrong start iterations fail the tests
* Prevent future regression: Add test ensuring model fits when using UTF-8 feature names