### PR TITLE
LightGBM: Upgrade to Fast Predict API and fix double free bug

### DIFF
--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModel.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModel.java
@@ -51,6 +51,11 @@ public class LightGBMBinaryClassificationModel implements ClassificationMLModel 
     private final LightGBMSWIG lgbm;
 
     /**
+     * String with LightGBM parameters used for prediction.
+     */
+    private static final String LightGBMPredictionParameters = "num_threads=1";
+
+    /**
      * Constructor.
      * Takes care of loading the model from the file and initializing all SWIG-LGBM resources for prediction.
      *
@@ -60,7 +65,7 @@ public class LightGBMBinaryClassificationModel implements ClassificationMLModel 
      */
     LightGBMBinaryClassificationModel(final Path modelPath, final DatasetSchema schema) throws ModelLoadingException {
         this.schema = schema;
-        lgbm = new LightGBMSWIG(modelPath.toString(), schema);
+        lgbm = new LightGBMSWIG(modelPath.toString(), schema, LightGBMPredictionParameters);
     }
 
     @Override

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModel.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModel.java
@@ -53,7 +53,7 @@ public class LightGBMBinaryClassificationModel implements ClassificationMLModel 
     /**
      * String with LightGBM parameters used for prediction.
      */
-    private static final String LightGBMPredictionParameters = "num_threads=1";
+    private static final String LIGHTGBM_PREDICTION_PARAMETERS = "num_threads=1";
 
     /**
      * Constructor.
@@ -65,7 +65,7 @@ public class LightGBMBinaryClassificationModel implements ClassificationMLModel 
      */
     LightGBMBinaryClassificationModel(final Path modelPath, final DatasetSchema schema) throws ModelLoadingException {
         this.schema = schema;
-        lgbm = new LightGBMSWIG(modelPath.toString(), schema, LightGBMPredictionParameters);
+        lgbm = new LightGBMSWIG(modelPath.toString(), schema, LIGHTGBM_PREDICTION_PARAMETERS);
     }
 
     @Override

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
@@ -74,15 +74,15 @@ class LightGBMSWIG {
      *
      * @param modelPath          Path to the model
      * @param schema             Input schema
-     * @param LightGBMParameters LightGBM parameters
+     * @param lightGBMParameters LightGBM parameters
      * @throws ModelLoadingException in case any LightGBM error occurs.
      */
     public LightGBMSWIG(final String modelPath,
-                        final DatasetSchema schema, final String LightGBMParameters) throws ModelLoadingException {
+                        final DatasetSchema schema, final String lightGBMParameters) throws ModelLoadingException {
 
         this.schemaNumFields = schema.getFieldSchemas().size();
         this.schemaTargetIndex = schema.getTargetIndex().orElse(-1);
-        this.swigResources = new SWIGResources(modelPath, LightGBMParameters);
+        this.swigResources = new SWIGResources(modelPath, lightGBMParameters);
 
         initBoosterNumClasses();
     }

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
@@ -75,7 +75,7 @@ class LightGBMSWIG {
      * @param schema    Input schema
      * @throws ModelLoadingException in case any LightGBM error occurs.
      */
-    LightGBMSWIG(final String modelPath, final DatasetSchema schema) throws ModelLoadingException {
+    public LightGBMSWIG(final String modelPath, final DatasetSchema schema) throws ModelLoadingException {
 
         final String LightGBMParameters = "num_threads=1";
 
@@ -137,7 +137,6 @@ class LightGBMSWIG {
             if (returnCodeLGBM == -1)
                 throw new LightGBMException();
 
-            // Valid for binary predictions:
             final double predictionScore = lightgbmlibJNI.doubleArray_getitem(this.swigResources.swigOutScoresPtr, 0);
             logger.trace("Prediction: {}", predictionScore);
             return new double[]{1 - predictionScore, predictionScore};

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
@@ -78,14 +78,13 @@ class LightGBMSWIG {
      */
     LightGBMSWIG(final String modelPath, final DatasetSchema schema) throws ModelLoadingException {
 
+        final String LightGBMParameters = "num_threads=1";
+
         this.schemaNumFields = schema.getFieldSchemas().size();
         this.schemaTargetIndex = schema.getTargetIndex().orElse(-1);
-        this.swigResources = new SWIGResources(modelPath);
+        this.swigResources = new SWIGResources(modelPath, LightGBMParameters);
 
         initBoosterNumClasses();
-
-        final String LightGBMParameters = "num_threads=1";
-        this.swigResources.initBoosterFastPredictHandle(LightGBMParameters); // TODO: merge this into SWIGResources()
     }
 
 
@@ -123,7 +122,7 @@ class LightGBMSWIG {
      * @param instance The instance from pulse.
      * @return double[2] array with scores.
      */
-    double[] getBinaryClassDistribution(final Instance instance) {
+    public double[] getBinaryClassDistribution(final Instance instance) {
 
         // we need to lock the resources to avoid having multiple threads sharing the same swig resources.
         synchronized (this.swigResources) {
@@ -153,7 +152,7 @@ class LightGBMSWIG {
      *
      * @return Number of features in the model (retrieved from model binary).
      */
-    int getBoosterNumFeatures() {
+    public int getBoosterNumFeatures() {
         return this.swigResources.getBoosterNumFeatures();
     }
 
@@ -179,7 +178,7 @@ class LightGBMSWIG {
      * @return Number of model classes (retrieved from model binary).
      *         NOTE: It's 1 for binary case in LightGBM!
      */
-    int getBoosterNumClasses() {
+    public int getBoosterNumClasses() {
         return this.boosterNumClasses;
     }
 
@@ -188,7 +187,7 @@ class LightGBMSWIG {
      *
      * @return Returns true if the model is binary.
      */
-    boolean isModelBinary() {
+    public boolean isModelBinary() {
         return this.boosterNumClasses == BINARY_LGBM_NUM_CLASSES;
     }
 
@@ -197,14 +196,14 @@ class LightGBMSWIG {
      *
      * @return The number of booster iterations in the model (retrieved from model binary).
      */
-    int getBoosterNumIterations() { return this.swigResources.getBoosterNumIterations(); }
+    public int getBoosterNumIterations() { return this.swigResources.getBoosterNumIterations(); }
 
     /**
      * Saves the model to disk.
      *
      * @param outputModelFilePath the path of the output LightGBM model file.
      */
-    void saveModelToDisk(final Path outputModelFilePath) {
+    public void saveModelToDisk(final Path outputModelFilePath) {
 
         logger.info("Saving model to disk.");
         logger.debug("Saving model to disk @ {}.", outputModelFilePath);

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
@@ -71,13 +71,14 @@ class LightGBMSWIG {
     /**
      * Will read the model at path and initialize it.
      * If any LightGBM error arises a ModelLoadingException is thrown.
-     * @param modelPath Path to the model
-     * @param schema    Input schema
+     *
+     * @param modelPath          Path to the model
+     * @param schema             Input schema
+     * @param LightGBMParameters LightGBM parameters
      * @throws ModelLoadingException in case any LightGBM error occurs.
      */
-    public LightGBMSWIG(final String modelPath, final DatasetSchema schema) throws ModelLoadingException {
-
-        final String LightGBMParameters = "num_threads=1";
+    public LightGBMSWIG(final String modelPath,
+                        final DatasetSchema schema, final String LightGBMParameters) throws ModelLoadingException {
 
         this.schemaNumFields = schema.getFieldSchemas().size();
         this.schemaTargetIndex = schema.getTargetIndex().orElse(-1);

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
@@ -20,7 +20,6 @@ package com.feedzai.openml.provider.lightgbm;
 import com.feedzai.openml.data.Instance;
 import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.provider.exception.ModelLoadingException;
-import com.microsoft.ml.lightgbm.lightgbmlibConstants;
 import com.microsoft.ml.lightgbm.lightgbmlibJNI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,7 +128,7 @@ class LightGBMSWIG {
 
             copyDataToSWIGInstance(instance);
             final int returnCodeLGBM = lightgbmlibJNI.LGBM_BoosterPredictForMatSingleRowFast(
-                    this.swigResources.swigFastConfigHandle, //this.swigResources.swigBoosterHandle,
+                    this.swigResources.swigFastConfigHandle,
                     this.swigResources.swigInstancePtr,
                     this.swigResources.swigOutLengthInt64Ptr,
                     this.swigResources.swigOutScoresPtr // preallocated memory

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
@@ -93,12 +93,13 @@ class SWIGResources implements AutoCloseable {
      * Constructor. Initializes a model handle and all resource handlers
      * necessary to implement the standard model operations.
      *
-     * @param modelPath         Path to the model folder.
+     * @param modelPath          Path to the model folder.
+     * @param LightGBMParameters String with LightGBM parameters.
      * @throws ModelLoadingException Error loading the model.
      * @throws LightGBMException     in case there's an error in the C++ core library.
      */
-    SWIGResources(final String modelPath,
-                  final String LightGBMParameters) throws ModelLoadingException, LightGBMException {
+    public SWIGResources(final String modelPath,
+                         final String LightGBMParameters) throws ModelLoadingException, LightGBMException {
 
         this.swigOutIntPtr = lightgbmlibJNI.new_intp();
         initModelResourcesFromFile(modelPath);

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
@@ -154,8 +154,8 @@ class SWIGResources implements AutoCloseable {
     }
 
     /**
-     * Initializes the FastPredict object from a Booster.
-     * This FastPredict config is responsible for caching Booster+Prediction settings for repeated prediction calls.
+     * Initializes the FastConfig object from a Booster.
+     * This FastConfig is responsible for caching Booster+Prediction settings for repeated prediction calls.
      * It is used in the *Fast() predict methods instead of the Booster and prediction settings.
      *
      * @param LightGBMParameters String with custom LightGBM parameters.

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
@@ -240,7 +240,6 @@ class SWIGResources implements AutoCloseable {
         // Delete FastConfig configuration resource:
         if (this.swigFastConfigHandle != null) {
             final int returnCodeLGBM = lightgbmlibJNI.LGBM_FastConfigFree(this.swigFastConfigHandle);
-            lightgbmlibJNI.delete_voidpp(this.swigFastConfigHandle);
             this.swigFastConfigHandle = null;
 
             if (returnCodeLGBM == -1) {
@@ -251,7 +250,6 @@ class SWIGResources implements AutoCloseable {
         // Delete model resources:
         if (this.swigBoosterHandle != null) {
             final int returnCodeLGBM = lightgbmlibJNI.LGBM_BoosterFree(this.swigBoosterHandle);
-            lightgbmlibJNI.delete_voidpp(this.swigBoosterHandle);
             this.swigBoosterHandle = null;
 
             if (returnCodeLGBM == -1) {

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGResources.java
@@ -44,28 +44,28 @@ class SWIGResources implements AutoCloseable {
     /**
      * SWIG pointer to BoosterHandle.
      */
-    Long swigBoosterHandle;
+    public Long swigBoosterHandle;
 
     /**
      * SWIG pointer to FastConfigHandle
      */
-    Long swigFastConfigHandle;
+    public Long swigFastConfigHandle;
 
     /**
      * Useless variable in the C API, for we already have to preallocate swigOutScoresPtr,
      * so we get no information from this API output.
      */
-    Long swigOutLengthInt64Ptr;
+    public Long swigOutLengthInt64Ptr;
 
     /**
      * Pointer to the instance array.
      */
-    Long swigInstancePtr;
+    public Long swigInstancePtr;
 
     /**
      * SWIG Pointer to the scored array output (pre-allocated by us).
      */
-    Long swigOutScoresPtr;
+    public Long swigOutScoresPtr;
 
     /**
      * A handler to collect a pointer to int output.
@@ -73,7 +73,7 @@ class SWIGResources implements AutoCloseable {
      * As many calls output an IntPtr, this field is useful
      * to avoid repeating pointer allocation/destruction ops.
      */
-    Long swigOutIntPtr;
+    public Long swigOutIntPtr;
 
     /**
      * Number of iterations in the trained LightGBM boosting model.
@@ -97,12 +97,14 @@ class SWIGResources implements AutoCloseable {
      * @throws ModelLoadingException Error loading the model.
      * @throws LightGBMException     in case there's an error in the C++ core library.
      */
-    SWIGResources(final String modelPath) throws ModelLoadingException, LightGBMException {
+    SWIGResources(final String modelPath,
+                  final String LightGBMParameters) throws ModelLoadingException, LightGBMException {
 
         this.swigOutIntPtr = lightgbmlibJNI.new_intp();
         initModelResourcesFromFile(modelPath);
         initGetBoosterNumFeatures();
         initAuxResources();
+        initBoosterFastPredictHandle(LightGBMParameters);
     }
 
     /**
@@ -159,7 +161,7 @@ class SWIGResources implements AutoCloseable {
      *
      * @throws ModelLoadingException in case there is a C++ back-end error creating the FastConfig object.
      */
-    void initBoosterFastPredictHandle(final String LightGBMParameters) throws ModelLoadingException {
+    private void initBoosterFastPredictHandle(final String LightGBMParameters) throws ModelLoadingException {
 
         final long swigOutFastConfigHandlePtr = lightgbmlibJNI.voidpp_handle();
 
@@ -271,14 +273,14 @@ class SWIGResources implements AutoCloseable {
      *
      * @return boosterNumIterations
      */
-    int getBoosterNumIterations() { return this.boosterNumIterations; }
+    public int getBoosterNumIterations() { return this.boosterNumIterations; }
 
     /**
      * Returns the number of features in the model.
      *
      * @return boosterNumIterations
      */
-    int getBoosterNumFeatures() { return this.boosterNumFeatures; }
+    public int getBoosterNumFeatures() { return this.boosterNumFeatures; }
 
     /**
      * Computes the number of features in the model.

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGTrainResources.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/SWIGTrainResources.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * @author Alberto Ferreira (alberto.ferreira@feedzai.com)
  * @since 1.0.10
  */
-public class SWIGTrainResources implements AutoCloseable {
+class SWIGTrainResources implements AutoCloseable {
 
     /**
      * Logger for this class.
@@ -44,7 +44,7 @@ public class SWIGTrainResources implements AutoCloseable {
     /**
      * Handle for the output parameter necessary for the LightGBM dataset instantiation.
      */
-    SWIGTYPE_p_p_void swigOutDatasetHandlePtr;
+    public SWIGTYPE_p_p_void swigOutDatasetHandlePtr;
 
     /**
      * SWIG pointer to the Features data array.
@@ -53,27 +53,27 @@ public class SWIGTrainResources implements AutoCloseable {
      * In the current implementation, features are stored in row-major order, i.e.,
      * each instance is stored contiguously.
      */
-    SWIGTYPE_p_double swigTrainFeaturesDataArray;
+    public SWIGTYPE_p_double swigTrainFeaturesDataArray;
 
     /**
      * SWIG pointer to the labels array (array of float32 elements).
      */
-    SWIGTYPE_p_float swigTrainLabelDataArray;
+    public SWIGTYPE_p_float swigTrainLabelDataArray;
 
     /**
      * SWIG LightGBM dataset handle.
      */
-    SWIGTYPE_p_void swigDatasetHandle;
+    public SWIGTYPE_p_void swigDatasetHandle;
 
     /**
      * SWIG pointer to the output LightGBM Booster Handle during Booster structure instantiation.
      */
-    SWIGTYPE_p_p_void swigOutBoosterHandlePtr;
+    public SWIGTYPE_p_p_void swigOutBoosterHandlePtr;
 
     /**
      * Handle of the LightGBM boosting model post-instantiation.
      */
-    SWIGTYPE_p_void swigBoosterHandle;
+    public SWIGTYPE_p_void swigBoosterHandle;
 
     /**
      * Constructor.
@@ -103,14 +103,14 @@ public class SWIGTrainResources implements AutoCloseable {
     /**
      * Setup swigDatasetHandle after its setup.
      */
-    void initSwigDatasetHandle() {
+    public void initSwigDatasetHandle() {
         this.swigDatasetHandle = lightgbmlib.voidpp_value(this.swigOutDatasetHandlePtr);
     }
 
     /**
      * Setup swigBoosterHandle after its structure was created in-memory.
      */
-    void initSwigBoosterHandle() {
+    public void initSwigBoosterHandle() {
         this.swigBoosterHandle = lightgbmlib.voidpp_value(this.swigOutBoosterHandlePtr);
     }
 
@@ -118,7 +118,7 @@ public class SWIGTrainResources implements AutoCloseable {
      * Release the memory of the label array.
      * This can be called after instantiating the dataset and setting the label in it.
      */
-    void destroySwigTrainLabelDataArray() {
+    public void destroySwigTrainLabelDataArray() {
 
         if (this.swigTrainLabelDataArray != null) {
             lightgbmlib.delete_floatArray(this.swigTrainLabelDataArray);
@@ -130,7 +130,7 @@ public class SWIGTrainResources implements AutoCloseable {
      * Release the memory of the features array.
      * This can be called after instantiating the dataset.
      */
-    void destroySwigTrainFeaturesDataArray() {
+    public void destroySwigTrainFeaturesDataArray() {
 
         if (this.swigTrainFeaturesDataArray != null) {
             lightgbmlib.delete_doubleArray(this.swigTrainFeaturesDataArray);
@@ -142,7 +142,7 @@ public class SWIGTrainResources implements AutoCloseable {
      * Release any allocated resources.
      * This operation is idempotent and can be safely called at any time as many times as you wish.
      */
-    void releaseResources() {
+    public void releaseResources() {
 
         if (this.swigOutDatasetHandlePtr != null) {
             lightgbmlib.delete_voidpp(this.swigOutDatasetHandlePtr);

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGResourcesTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGResourcesTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.provider.lightgbm;
+
+import com.feedzai.openml.provider.exception.ModelLoadingException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for the SWIGResources class to ensure all resources are properly/safely initialized and released.
+ *
+ * @author Alberto Ferreira (alberto.ferreira@feedzai.com)
+ * @since 1.0.18
+ */
+public class SWIGResourcesTest {
+
+    /**
+     * Standard model path.
+     */
+    static Path modelPath;
+
+    /**
+     * SWIGResources instance common to all tests. Do not modify it!
+     * Used to speed up tests by avoiding re-reading the model file.
+     */
+    static SWIGResources defaultSwig;
+
+    /**
+     * Set up the standard model path.
+     *
+     * @throws URISyntaxException Couldn't extract file resource.
+     */
+    @BeforeClass
+    static public void setupFixture() throws ModelLoadingException, URISyntaxException {
+
+        LightGBMUtils.loadLibs(); // Initialize LightGBM libs.
+
+        modelPath = TestResources.getModelFilePath();
+        defaultSwig = new SWIGResources(modelPath.toString(), "");
+    }
+
+    /**
+     * Test SWIGResources() - all public members should be initialized.
+     */
+    @Test
+    public void constructorInitializesAllPublicMembers() {
+
+        assertThat(defaultSwig.swigBoosterHandle).as("swigBoosterHandle").isNotNull();
+        assertThat(defaultSwig.swigFastConfigHandle).as("swigFastConfigHandle").isNotNull();
+        assertThat(defaultSwig.swigInstancePtr).as("swigInstancePtr").isNotNull();
+        assertThat(defaultSwig.swigOutIntPtr).as("swigOutIntPtr").isNotNull();
+        assertThat(defaultSwig.swigOutLengthInt64Ptr).as("swigOutLengthInt64Ptr").isNotNull();
+        assertThat(defaultSwig.swigOutScoresPtr).as("swigOutScoresPtr").isNotNull();
+    }
+
+    /**
+     * Test SWIGResources() - A ModelLoadingException is thrown when the modelPath does not point to a valid model file.
+     */
+    @Test
+    public void constructorThrowsModelLoadingExceptionOnInvalidModelPath() {
+
+        assertThatExceptionOfType(ModelLoadingException.class).isThrownBy(() ->
+                new SWIGResources("__invalid_model_path__", ""));
+    }
+
+    /**
+     * Test close() - All public fields should be freed and set to null.
+     */
+    @Test
+    public void closeResetsAllPublicMembers() throws ModelLoadingException {
+
+        // Generate a new SWIGResources instance as it will be modified:
+        SWIGResources swig = new SWIGResources(modelPath.toString(), "");
+        swig.close();
+
+        assertThat(swig.swigBoosterHandle).as("swigBoosterHandle").isNull();
+        assertThat(swig.swigFastConfigHandle).as("swigFastConfigHandle").isNull();
+        assertThat(swig.swigInstancePtr).as("swigInstancePtr").isNull();
+        assertThat(swig.swigOutIntPtr).as("swigOutIntPtr").isNull();
+        assertThat(swig.swigOutLengthInt64Ptr).as("swigOutLengthInt64Ptr").isNull();
+        assertThat(swig.swigOutScoresPtr).as("swigOutScoresPtr").isNull();
+    }
+
+    /**
+     * Test getBoosterNumIterations() - Should return the correct number.
+     */
+    @Test
+    public void getBoosterNumIterationsReturnsCorrectValue() {
+
+        assertThat(defaultSwig.getBoosterNumIterations()).as("number of booster iterations").isEqualTo(200);
+    }
+
+    /**
+     * Test getBoosterNumFeatures() - Should return the correct number.
+     */
+    @Test
+    public void getBoosterNumFeaturesReturnsCorrectValue() {
+
+        assertThat(defaultSwig.getBoosterNumFeatures()).as("number of booster features").isEqualTo(4);
+    }
+}

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGResourcesTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGResourcesTest.java
@@ -38,13 +38,13 @@ public class SWIGResourcesTest {
     /**
      * Standard model path.
      */
-    static Path modelPath;
+    private static Path modelPath;
 
     /**
      * SWIGResources instance common to all tests. Do not modify it!
      * Used to speed up tests by avoiding re-reading the model file.
      */
-    static SWIGResources defaultSwig;
+    private static SWIGResources defaultSwig;
 
     /**
      * Set up the standard model path.
@@ -52,7 +52,7 @@ public class SWIGResourcesTest {
      * @throws URISyntaxException Couldn't extract file resource.
      */
     @BeforeClass
-    static public void setupFixture() throws ModelLoadingException, URISyntaxException {
+    public static void setupFixture() throws ModelLoadingException, URISyntaxException {
 
         LightGBMUtils.loadLibs(); // Initialize LightGBM libs.
 

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGTrainResourcesTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGTrainResourcesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.provider.lightgbm;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the SWIGTrainResources class to ensure all resources are properly/safely initialized and released.
+ *
+ * @author Alberto Ferreira (alberto.ferreira@feedzai.com)
+ * @since 1.0.18
+ */
+public class SWIGTrainResourcesTest {
+
+    /**
+     * SWIGResources instance common to all tests. Do not modify it!
+     * Used to speed up tests by avoiding re-reading the model file.
+     */
+    private SWIGTrainResources swigTrainResources;
+
+    /**
+     * Set up the LightGBM libs.
+     */
+    @BeforeClass
+    public static void setupFixture() {
+
+        LightGBMUtils.loadLibs(); // Initialize LightGBM libs.
+    }
+
+    /**
+     * Set up a fresh SWIGTrainResources test instance for every test.
+     */
+    @Before
+    public void setupTest() {
+
+        swigTrainResources = new SWIGTrainResources(100, 10);
+    }
+
+    /**
+     * Test SWIGTrainResources() - some public members should be initialized.
+     */
+    @Test
+    public void constructorInitializesPublicMembers() {
+
+        assertThat(swigTrainResources.swigOutDatasetHandlePtr).as("swigOutDatasetHandlePtr").isNotNull();
+        assertThat(swigTrainResources.swigTrainFeaturesDataArray).as("swigTrainFeaturesDataArray").isNotNull();
+        assertThat(swigTrainResources.swigTrainLabelDataArray).as("swigTrainLabelDataArray").isNotNull();
+        assertThat(swigTrainResources.swigOutBoosterHandlePtr).as("swigOutBoosterHandlePtr").isNotNull();
+        // Cannot assert those as they require external initialization:
+        //assertThat(swigTrainResources.swigDatasetHandle).as("swigDatasetHandle").isNotNull();
+        //assertThat(swigTrainResources.swigBoosterHandle).as("swigBoosterHandle").isNotNull();
+    }
+
+    /**
+     * Test close() - All public fields should be freed and set to null.
+     */
+    @Test
+    public void closeResetsAllPublicMembers() {
+
+        swigTrainResources.releaseResources();
+
+        assertThat(swigTrainResources.swigOutDatasetHandlePtr).as("swigOutDatasetHandlePtr").isNull();
+        assertThat(swigTrainResources.swigTrainFeaturesDataArray).as("swigTrainFeaturesDataArray").isNull();
+        assertThat(swigTrainResources.swigTrainLabelDataArray).as("swigTrainLabelDataArray").isNull();
+        assertThat(swigTrainResources.swigOutBoosterHandlePtr).as("swigOutBoosterHandlePtr").isNull();
+        assertThat(swigTrainResources.swigDatasetHandle).as("swigDatasetHandle").isNull();
+        assertThat(swigTrainResources.swigBoosterHandle).as("swigBoosterHandle").isNull();
+    }
+
+}

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGTrainResourcesTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGTrainResourcesTest.java
@@ -32,8 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SWIGTrainResourcesTest {
 
     /**
-     * SWIGResources instance common to all tests. Do not modify it!
-     * Used to speed up tests by avoiding re-reading the model file.
+     * SWIGTrainResources instance common to all tests.
+     * Fresh instance initialized before each test.
      */
     private SWIGTrainResources swigTrainResources;
 
@@ -65,9 +65,9 @@ public class SWIGTrainResourcesTest {
         assertThat(swigTrainResources.swigTrainFeaturesDataArray).as("swigTrainFeaturesDataArray").isNotNull();
         assertThat(swigTrainResources.swigTrainLabelDataArray).as("swigTrainLabelDataArray").isNotNull();
         assertThat(swigTrainResources.swigOutBoosterHandlePtr).as("swigOutBoosterHandlePtr").isNotNull();
-        // Cannot assert those as they require external initialization:
-        //assertThat(swigTrainResources.swigDatasetHandle).as("swigDatasetHandle").isNotNull();
-        //assertThat(swigTrainResources.swigBoosterHandle).as("swigBoosterHandle").isNotNull();
+        /* Cannot assert these two as they require external initialization:
+         assertThat(swigTrainResources.swigDatasetHandle).as("swigDatasetHandle").isNotNull();
+         assertThat(swigTrainResources.swigBoosterHandle).as("swigBoosterHandle").isNotNull(); */
     }
 
     /**


### PR DESCRIPTION
* Use the newer prediction *Fast() methods and FastConfig
* Reduce temporary object creation (less GC in prediction for better latencies)
* Number of features in prediction classes is now computed from the model (cleaner)
* Visibility refactor for methods in the SWIG helper classes
* Add SWIGResourcesTest and SWIGResourcesTest classes to test resource initialization/release
* Found and fixed 2 double free bugs in SWIGResources
* Instead of hardcoded in LightGBMSWIG, LightGBM prediction parameters are passed to the constructor