### PR TITLE
Fix missing lightgbm dependencies on uber jar

### DIFF
--- a/openml-lightgbm/lightgbm-builder/javadoc/README.md
+++ b/openml-lightgbm/lightgbm-builder/javadoc/README.md
@@ -1,2 +1,0 @@
-# Ligthgbm Lib Javadoc
-This is a dummy javadoc.

--- a/openml-lightgbm/lightgbm-builder/pom.xml
+++ b/openml-lightgbm/lightgbm-builder/pom.xml
@@ -41,88 +41,6 @@
         <lightgbmlib.version>3.0.0</lightgbmlib.version>
     </properties>
 
-    <!-- jgitver changes the version 2.3.190 to project version, therefore we excluded this project from jgitver -->
-    <!-- for this reason we can't use parent on this module, so I'm repeating this profile from root pom -->
-    <organization>
-        <name>Feedzai</name>
-        <url>https://www.feedzai.com</url>
-    </organization>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/feedzai/feedzai-openml-java/issues</url>
-    </issueManagement>
-
-    <scm>
-        <url>https://github.com/feedzai/feedzai-openml-java</url>
-        <developerConnection>scm:git:git@github.com:feedzai/feedzai-openml-java.git</developerConnection>
-    </scm>
-
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <name>Feedzai OpenML</name>
-            <organization>Feedzai</organization>
-            <url>https://github.com/feedzai/feedzai-openml-java/issues</url>
-        </developer>
-    </developers>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <properties>
-                <gpg.executable>gpg</gpg.executable>
-                <gpg.keyname>${env.PGP_KEY_ID}</gpg.keyname>
-                <gpg.passphrase>${env.PGP_PASS}</gpg.passphrase>
-                <gpg.defaultKeyring>false</gpg.defaultKeyring>
-                <gpg.homedir>${user.dir}/.gnupg</gpg.homedir>
-            </properties>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.4</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <build>
         <resources>
             <resource>
@@ -190,45 +108,15 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <!-- skip deployment because lightgbm-lib is already included in uber jar -->
+                    <skip>true</skip>
+                </configuration>
             </plugin>
 
-            <!-- This will create a dummy javadoc -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>javadoc</classifier>
-                            <classesDirectory>${basedir}/javadoc</classesDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
 </project>

--- a/openml-lightgbm/lightgbm-provider/pom.xml
+++ b/openml-lightgbm/lightgbm-provider/pom.xml
@@ -34,6 +34,7 @@
             <groupId>com.feedzai.openml.lightgbm</groupId>
             <artifactId>lightgbm-lib</artifactId>
             <version>${lightgbmlib.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/openml-lightgbm/lightgbm-provider/src/assembly/dist.xml
+++ b/openml-lightgbm/lightgbm-provider/src/assembly/dist.xml
@@ -12,7 +12,7 @@
             <outputDirectory>/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <unpack>true</unpack>
-            <scope>runtime</scope>
+            <scope>provided</scope>
             <includes>
                 <include>com.feedzai.openml.lightgbm:lightgbm-lib</include>
                 <include>com.feedzai:openml-lightgbm</include>


### PR DESCRIPTION
The commit ad56167 from MR #47 deploys lightgbm-lib as an independent jar to the remote repository. Which wasn't desired.

This commit amends the previous undesired behaviour by:

1. including ligthgmb-lib in the uber jar;

1. making lightgbm-lib non-transitive.

This way prevents to deploy to a remote repository.
