### PR TITLE
LightGBM: Validate Feature Names on Model Import

### DIFF
--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModel.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModel.java
@@ -110,6 +110,14 @@ public class LightGBMBinaryClassificationModel implements ClassificationMLModel 
     }
 
     /**
+     * @return Names of the features in the model.
+     * @since 1.0.18
+     */
+    public String[] getBoosterFeatureNames() {
+        return lgbm.getBoosterFeatureNames();
+    }
+
+    /**
      * @return The number of booster iterations in the model.
      */
     public int getBoosterNumIterations() { return lgbm.getBoosterNumIterations(); }

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMSWIG.java
@@ -156,6 +156,16 @@ class LightGBMSWIG {
     }
 
     /**
+     * Gets the name of the features in the model.
+     *
+     * @return Names of the features in the model (retrieved from model binary).
+     * @since 1.0.18
+     */
+    public String[] getBoosterFeatureNames() {
+        return this.swigResources.getBoosterFeatureNames();
+    }
+
+    /**
      * Initializes the number of model classes from the model binary.
      *
      * <p><b>Note</b> that this method is not thread safe (by itself) and thus needs to be called in a synchronized

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMModelCreatorTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMModelCreatorTest.java
@@ -39,6 +39,7 @@ import static com.feedzai.openml.provider.lightgbm.LightGBMModelCreator.ERROR_MS
 import static com.feedzai.openml.provider.lightgbm.LightGBMModelCreator.ERROR_MSG_PREFIX_CANNOT_FIND_MODEL_FILE;
 import static com.feedzai.openml.provider.lightgbm.LightGBMModelCreator.ERROR_MSG_RANDOM_FOREST_REQUIRES_BAGGING;
 import static com.feedzai.openml.provider.lightgbm.LightGBMModelCreator.ERROR_MSG_SCHEMA_HAS_STRING_FIELDS;
+import static com.feedzai.openml.provider.lightgbm.LightGBMModelCreator.ERROR_MSG_SCHEMA_WITH_WRONG_PREDICTIVE_FIELD_NAMES;
 import static com.feedzai.openml.provider.lightgbm.LightGBMModelCreator.ERROR_MSG_SCHEMA_WITH_WRONG_PREDICTIVE_FIELDS_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -282,6 +283,23 @@ public class LightGBMModelCreatorTest {
                     TestSchemas.BAD_NUMERICALS_SCHEMA_WITH_MISSING_FIELDS
             )
         ).withMessage(ERROR_MSG_SCHEMA_WITH_WRONG_PREDICTIVE_FIELDS_SIZE);
+    }
+
+    /**
+     * Assert that loading a model with a wrong field
+     * names order throws a ModelLoadingException.
+     *
+     * @since 1.0.18
+     */
+    @Test
+    public void loadModelWithWrongFieldNamesOrderThrowsTest() {
+
+        assertThatExceptionOfType(ModelLoadingException.class).isThrownBy(() ->
+                modelLoader.loadModel(
+                        TestResources.getModelFilePath(),
+                        TestSchemas.BAD_NUMERICALS_SCHEMA_WITH_WRONG_FEATURES_ORDER
+                )
+        ).withMessage(ERROR_MSG_SCHEMA_WITH_WRONG_PREDICTIVE_FIELD_NAMES);
     }
 
     /**


### PR DESCRIPTION
Additional validation step on `loadModel` ensures schema predictive field names match model booster feature names.
 * The implementation assumes that model booster features representation, replaces whitespaces with underscores
 * The error scenario was tested with the existing numerical schema with unordered features