### PR TITLE
Add missing dependencies

### DIFF
--- a/openml-datarobot/pom.xml
+++ b/openml-datarobot/pom.xml
@@ -98,6 +98,12 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <!--Guava-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -158,6 +158,24 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,24 @@
                 <version>${apache.version}</version>
                 <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.6.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.25</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.7</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This commit adds missing dependencies in the pom files that were already being used.
It also changes the Guava dependency in `openml-datarobot` module to `provided`.
This will exclude Guava from the generated fat jar with the dependencies.