### PR TITLE
pom: Bump openml-api which now uses Guava 25.1 and add missing dependencies

### DIFF
--- a/openml-datarobot/pom.xml
+++ b/openml-datarobot/pom.xml
@@ -64,6 +64,12 @@
             <version>1.0.4</version>
         </dependency>
 
+        <!--Guava-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>

--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -55,7 +55,18 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>
@@ -187,6 +198,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/openml-java-utils/pom.xml
+++ b/openml-java-utils/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/openml-lightgbm/lightgbm-provider/pom.xml
+++ b/openml-lightgbm/lightgbm-provider/pom.xml
@@ -52,7 +52,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.auto.service</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <project.source>1.8</project.source>
         <junit.version>4.13.1</junit.version>
         <assertj.version>3.7.0</assertj.version>
-        <openml-api.version>1.0.3</openml-api.version>
+        <openml-api.version>1.1.0</openml-api.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
         <commons-io.version>2.4</commons-io.version>
@@ -132,6 +132,24 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.6.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.25</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.7</version>
             </dependency>
 
             <!--Testing-->


### PR DESCRIPTION
This commit upgrades OpenML and also upgrades Guava to version 25.1.
It changes the `Guava` dependency to scope `compile` so it is bundled in the generated Uber Jars.
And also adds some missing dependencies that were being used without being declared like:
`com.google.code.gson:gson`
`org.slf4j:slf4j-api`
`org.apache.commons:commons-lang3`
and `ch.qos.logback:logback-classic`