### PR TITLE
pom: Bump log4j to version 1.2.17-cloudera1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <jackson-databind.version>2.6.7</jackson-databind.version>
         <commons-io.version>2.4</commons-io.version>
         <apache.version>1.8</apache.version>
+        <log4j.version>1.2.17-cloudera1</log4j.version>
     </properties>
 
     <dependencyManagement>
@@ -150,6 +151,13 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.7</version>
+            </dependency>
+
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+                <scope>compile</scope>
             </dependency>
 
             <!--Testing-->
@@ -365,4 +373,11 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    <repositories>
+        <repository>
+            <id>icm</id>
+            <name>icm</name>
+            <url>http://maven.icm.edu.pl/artifactory/repo/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
This commit upgrades log4j from version 1.2.17 to 1.2.17-cloudera1, since the
older version had some CVEs.
Note that, even though we haven't declared the log4j dependency before, we were
using it since it was a transitive dependency from `ai.h2o:h2o-core`.