### PR TITLE
Remove kotlin dependency from the shaded jar

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -253,6 +253,7 @@
                                         <exclude>org/slf4j/**</exclude>
                                         <exclude>com/esotericsoftware/kryo/**</exclude>
                                         <exclude>org/objenesis/**</exclude>
+                                        <exclude>kotlin/**</exclude>
                                         <!-- The following two libraries were removed because they were under-performing in cluster environments-->
                                         <exclude>**/libxgboost4j_gpu.so</exclude>
                                         <exclude>**/libxgboost4j_omp.so</exclude>


### PR DESCRIPTION
This commit removes Kotlin dependency from the shaded jar as it conflicts with the other libraries that use a more up-to-date version.