### PR TITLE
[fix] LightGBM: Load libs in SWIGChunkedArrayAPITest

### DIFF
--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
@@ -17,7 +17,6 @@
 
 package com.feedzai.openml.provider.lightgbm;
 
-import com.feedzai.openml.provider.exception.ModelLoadingException;
 import com.microsoft.ml.lightgbm.SWIGTYPE_p_double;
 import com.microsoft.ml.lightgbm.SWIGTYPE_p_int;
 import com.microsoft.ml.lightgbm.SWIGTYPE_p_p_void;
@@ -27,8 +26,6 @@ import com.microsoft.ml.lightgbm.lightgbmlibConstants;
 import org.assertj.core.data.Offset;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
@@ -45,9 +45,8 @@ public class SWIGChunkedArrayAPITest {
     @BeforeClass
     static public void setupFixture() {
         /* Needed as we'll directly call the low-level ChunkedArray class,
-         * even without using the provider which usually handles this step for us.
-         * As such, to not depend on test order execution we must load it
-         * the libraries explicitly here:
+         * without using the provider which usually handles this step for us.
+         * To avoid depending on test execution order we load the libraries explicitly:         
          */
         LightGBMUtils.loadLibs();
     }

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
@@ -45,8 +45,7 @@ public class SWIGChunkedArrayAPITest {
     @BeforeClass
     static public void setupFixture() {
         /* Needed as we'll directly call the low-level ChunkedArray class,
-         * without using the provider which usually handles this step for us.
-         * To avoid depending on test execution order we load the libraries explicitly:         
+         * without using the provider which usually loads the libraries for us.
          */
         LightGBMUtils.loadLibs();
     }

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
@@ -17,6 +17,7 @@
 
 package com.feedzai.openml.provider.lightgbm;
 
+import com.feedzai.openml.provider.exception.ModelLoadingException;
 import com.microsoft.ml.lightgbm.SWIGTYPE_p_double;
 import com.microsoft.ml.lightgbm.SWIGTYPE_p_int;
 import com.microsoft.ml.lightgbm.SWIGTYPE_p_p_void;
@@ -24,7 +25,10 @@ import com.microsoft.ml.lightgbm.doubleChunkedArray;
 import com.microsoft.ml.lightgbm.lightgbmlib;
 import com.microsoft.ml.lightgbm.lightgbmlibConstants;
 import org.assertj.core.data.Offset;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +40,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since @@@next.release@@@
  */
 public class SWIGChunkedArrayAPITest {
+
+    /**
+     * Must load the libraries so that the rest of the classes work.
+     * Without the libraries instantiated, not even LightGBM exceptions can be thrown.
+     */
+    @BeforeClass
+    static public void setupFixture() {
+        LightGBMUtils.loadLibs(); // Needed as we'll directly call the ChunkedArray class.
+    }
 
     /**
      * Test that using a ChunkedArray&ltdouble&gt works.

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/SWIGChunkedArrayAPITest.java
@@ -44,7 +44,12 @@ public class SWIGChunkedArrayAPITest {
      */
     @BeforeClass
     static public void setupFixture() {
-        LightGBMUtils.loadLibs(); // Needed as we'll directly call the ChunkedArray class.
+        /* Needed as we'll directly call the low-level ChunkedArray class,
+         * even without using the provider which usually handles this step for us.
+         * As such, to not depend on test order execution we must load it
+         * the libraries explicitly here:
+         */
+        LightGBMUtils.loadLibs();
     }
 
     /**


### PR DESCRIPTION
SWIGChunkedArrayAPITest uses low-level C++ features without calling the provider
which usually handles the loading of the LGBM libraries for us.

This PR fixes it by loading the libraries explicitly.