### PR TITLE
Fix jgitver version computation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,11 @@ on:
       - master
       - 'hf-*'    # hotfix branches
     tags:
-      - '*.*.*-*' # xx.yy.zz-experimental
       - '*.*.*'   # release tag xx.yy.zz
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'hf-*'
 
 jobs:
 
@@ -21,6 +22,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: |
+          git fetch -f --tags
+          echo exit code $?
+          git tag --list
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '*.*.*'
-      - '*.*.*-*'
 
 jobs:
 
@@ -15,6 +14,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: |
+          git fetch -f --tags
+          echo exit code $?
+          git tag --list
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -17,7 +17,8 @@
 <configuration xmlns="http://jgitver.github.io/maven/configuration/1.0.0-beta"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.0.0-beta https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_0_0-beta.xsd ">
-    <regexVersionTag>[rv]?([0-9.]+)</regexVersionTag>
+    <regexVersionTag>^([0-9\.]+)(-(GA|beta|alpha|xp.*))?$</regexVersionTag>
+    <mavenLike>true</mavenLike>
     <branchPolicies>
         <branchPolicy>
             <pattern>(hf-.*)</pattern> <!-- regex pattern for hotfix branches -->


### PR DESCRIPTION
jgitver was not comuting versions correctly since Github Actions didn't fetch the necessary tags.
This commit corrects the issue for the tags.

**Experimental tags were removed as they are not supported by jgitver (they should be based on the branch with a different action yaml).** - They were not working properly on TravisCI either.