### PR TITLE
ref PULSEDEV-35240 mvn configuration : Added custom maven settings to unblock http repository

### DIFF
--- a/.mvn/custom-settings.xml
+++ b/.mvn/custom-settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>icm-unblocker</id>
+            <mirrorOf>icm</mirrorOf>
+            <name/>
+            <url>http://maven.icm.edu.pl/artifactory/repo/</url>
+            <blocked>false</blocked>
+        </mirror>
+    </mirrors>
+</settings>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings ./.mvn/custom-settings.xml


### PR DESCRIPTION
New maven versions block HTTP repositories and this is causing the builds to fail as some dependencies cannot be downloaded by the git CI.

This PR attempts to fix this by using the approach described in https://stackoverflow.com/questions/67001968/how-to-disable-maven-blocking-external-http-repositores/67002852#67002852