### PR TITLE
ref PULSEDEV-35849 mvn: Update httpclient dependency version to HF-1.0.X

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -61,7 +61,7 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>provided</scope>
-            <version>4.5.5</version>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
So that commons-codec version is also bumped and the bug related to class colision in pulse is fixed.