### PR TITLE
ft ml PULSEDEV 35849 bump in hf 1 0 X

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -61,7 +61,7 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>provided</scope>
-            <version>4.5.5</version>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <openml-api.version>1.0.3</openml-api.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.7</commons-io.version>
         <apache.version>1.8</apache.version>
     </properties>
 


### PR DESCRIPTION
- Bump httpclient from 4.5.5 to 4.5.13 in /openml-h2o
- Update make-lightgbm submodule
- Bump commons-io from 2.4 to 2.7
