### PR TITLE
ft ml PULSEDEV 35849 bump in hf 1 2 X

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -73,7 +73,7 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>provided</scope>
-            <version>4.5.5</version>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
         <jackson-databind.version>2.6.7</jackson-databind.version>
         <commons-io.version>2.7</commons-io.version>
         <apache.version>1.8</apache.version>
-        <log4j.version>1.2.17-cloudera1</log4j.version>
     </properties>
 
     <dependencyManagement>
@@ -154,10 +153,9 @@
             </dependency>
 
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.version}</version>
-                <scope>compile</scope>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.14.1</version>
             </dependency>
 
             <!--Testing-->
@@ -380,11 +378,4 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-    <repositories>
-        <repository>
-            <id>icm</id>
-            <name>icm</name>
-            <url>http://maven.icm.edu.pl/artifactory/repo/</url>
-        </repository>
-    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <openml-api.version>1.1.0</openml-api.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.7</commons-io.version>
         <apache.version>1.8</apache.version>
         <log4j.version>1.2.17-cloudera1</log4j.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <jackson-databind.version>2.6.7</jackson-databind.version>
         <commons-io.version>2.7</commons-io.version>
         <apache.version>1.8</apache.version>
+        <log4j.version>2.14.1</log4j.version>
     </properties>
 
     <dependencyManagement>
@@ -155,7 +156,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.14.1</version>
+                <version>${log4j.version}</version>
             </dependency>
 
             <!--Testing-->


### PR DESCRIPTION
- Bump httpclient from 4.5.5 to 4.5.13 in /openml-h2o
- Update make-lightgbm submodule
- Bump commons-io from 2.4 to 2.7
- Since it was crashing the build in github actions because mvn no longer
allows usage of insecure http repositories. For that reason, we bumped
from [log4j](https://mvnrepository.com/artifact/log4j/log4j/1.2.17-cloudera1) to [log4j-core](https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core/2.14.1)
