### PR TITLE
upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.21.0</version>
+                    <version>3.0.0-M5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -241,7 +241,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.0</version>
+                <version>0.8.4</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Currently there is `Corrupted STDOUT by directly writing to native stream in forked JVM 1` warning.
The currently PR upgrades two dependencies that solve the warning see [solutions](https://exerror.com/corrupted-stdout-by-directly-writing-to-native-stream-in-forked-jvm-4/).