### PR TITLE
Bump jetty and log4j in H2O provider to avoid CVEs

### DIFF
--- a/openml-datarobot/pom.xml
+++ b/openml-datarobot/pom.xml
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -30,7 +30,7 @@
     <description>Contains classes and logic related with the import of H2O models.</description>
 
     <properties>
-        <h2o.version>3.30.0.7</h2o.version>
+        <h2o.version>3.36.0.3</h2o.version>
     </properties>
 
     <dependencies>
@@ -86,10 +86,16 @@
             <groupId>ai.h2o</groupId>
             <artifactId>h2o-core</artifactId>
             <version>${h2o.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j</artifactId>
+                    <groupId>log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ai.h2o</groupId>
-            <artifactId>h2o-jetty-9</artifactId>
+            <artifactId>h2o-jetty-9-minimal</artifactId>
             <version>${h2o.version}</version>
         </dependency>
         <dependency>
@@ -134,6 +140,12 @@
         <dependency>
             <groupId>ai.h2o</groupId>
             <artifactId>h2o-ext-xgboost</artifactId>
+            <version>${h2o.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ai.h2o</groupId>
+            <artifactId>h2o-logging-impl-log4j2</artifactId>
             <version>${h2o.version}</version>
         </dependency>
 
@@ -238,7 +250,7 @@
                             <relocations>
                                 <relocation>
                                     <pattern>org.eclipse.jetty</pattern>
-                                    <shadedPattern>feedzai.jetty8.shaded.org.eclipse.jetty</shadedPattern>
+                                    <shadedPattern>feedzai.jetty9.shaded.org.eclipse.jetty</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/H2OModelCreator.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/H2OModelCreator.java
@@ -60,6 +60,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.feedzai.openml.java.utils.ModelParameterUtils.getEffectiveModelParameterValues;
+
 /**
  * Implementation of the {@link MachineLearningModelLoader}.
  * <p>
@@ -208,9 +210,10 @@ public class H2OModelCreator implements MachineLearningModelTrainer<AbstractClas
                                                       final DatasetSchema schema,
                                                       final Map<String, String> params) {
 
+        final Map<String, String> effectiveModelParams = getEffectiveModelParameterValues(this.algorithm, params);
         final ImmutableList.Builder<ParamValidationError> errorBuilder = ImmutableList.builder();
 
-        errorBuilder.addAll(ValidationUtils.baseLoadValidations(schema, params));
+        errorBuilder.addAll(ValidationUtils.baseLoadValidations(schema, effectiveModelParams));
         errorBuilder.addAll(ValidationUtils.validateModelInDir(modelPath));
 
         if (schema.getTargetIndex().isPresent()) {
@@ -224,9 +227,11 @@ public class H2OModelCreator implements MachineLearningModelTrainer<AbstractClas
     public AbstractClassificationH2OModel fit(final Dataset dataset,
                                               final Random random,
                                               final Map<String, String> params) throws ModelTrainingException {
+
+        final Map<String, String> effectiveModelParams = getEffectiveModelParameterValues(this.algorithm, params);
         try {
             final Path datasetPath = H2OUtils.writeDatasetToDisk(dataset);
-            final Model model = this.h2OApp.train(this.algorithm, datasetPath, dataset.getSchema(), params, random.nextLong());
+            final Model model = this.h2OApp.train(this.algorithm, datasetPath, dataset.getSchema(), effectiveModelParams, random.nextLong());
 
             final Path exportPath = Files.createTempDirectory(H2OUtils.FEEDZAI_H2O_PREFIX + model._output._job._result.toString());
             final Path modelPath = Files.createDirectory(exportPath.resolve(LoadModelUtils.MODEL_FOLDER));
@@ -247,10 +252,11 @@ public class H2OModelCreator implements MachineLearningModelTrainer<AbstractClas
                                                      final DatasetSchema schema,
                                                      final Map<String, String> params) {
 
+        final Map<String, String> effectiveModelParams = getEffectiveModelParameterValues(this.algorithm, params);
         final ImmutableList.Builder<ParamValidationError> errorBuilder = ImmutableList.builder();
 
         errorBuilder.addAll(ValidationUtils.validateModelPathToTrain(pathToPersist));
-        errorBuilder.addAll(ValidationUtils.checkParams(this.algorithm, params));
+        errorBuilder.addAll(ValidationUtils.checkParams(this.algorithm, effectiveModelParams));
 
         errorBuilder.addAll(this.h2OApp.validate(this.algorithm, schema, params));
 

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelProviderTrainTest.java
@@ -283,9 +283,10 @@ public class H2OModelProviderTrainTest extends AbstractProviderModelTrainTest<Ab
                 params
         );
 
-        assertThat(paramValidationErrors.size())
+        assertThat(paramValidationErrors)
                 .as("The list parameter validation errors must be null.")
-                .isEqualTo(0);
+                .asList()
+                .isEmpty();
     }
 
 }

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/algos/ParametersTest.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/algos/ParametersTest.java
@@ -65,7 +65,7 @@ public class ParametersTest {
 
             assertThat(parameters.size())
                     .as("The number of parameters")
-                    .isGreaterThanOrEqualTo(10);
+                    .isGreaterThanOrEqualTo(5);
 
             assertThat(parameters.stream().anyMatch(ModelParameter::isMandatory))
                     .as("There is at least 1 mandatory parameter")

--- a/openml-java-utils/pom.xml
+++ b/openml-java-utils/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openml-java-utils/src/main/java/com/feedzai/openml/java/utils/ModelParameterUtils.java
+++ b/openml-java-utils/src/main/java/com/feedzai/openml/java/utils/ModelParameterUtils.java
@@ -23,11 +23,9 @@ import com.feedzai.openml.provider.descriptor.fieldtype.ChoiceFieldType;
 import com.feedzai.openml.provider.descriptor.fieldtype.FreeTextFieldType;
 import com.feedzai.openml.provider.descriptor.fieldtype.ModelParameterType;
 import com.feedzai.openml.provider.descriptor.fieldtype.NumericFieldType;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.MapDifference;
-import com.google.common.collect.Maps;
 
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -56,16 +54,11 @@ public final class ModelParameterUtils {
                                                                        final Map<String, String> newParams) {
 
         final Map<String, String> defaultValues = getDefaultModelParameterValues(algorithm);
-        final MapDifference<String, String> difference = Maps.difference(defaultValues, newParams);
-        final Map<String, String> rightParamsFromEntriesInCommon = difference.entriesDiffering().entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, a -> a.getValue().rightValue()));
-
-        final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        builder.putAll(difference.entriesOnlyOnLeft());
-        builder.putAll(difference.entriesInCommon());
-        builder.putAll(rightParamsFromEntriesInCommon);
-
-        return builder.build();
+        return defaultValues.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> newParams.getOrDefault(entry.getKey(), entry.getValue())
+                ));
     }
 
     /**

--- a/openml-java-utils/src/main/java/com/feedzai/openml/java/utils/ModelParameterUtils.java
+++ b/openml-java-utils/src/main/java/com/feedzai/openml/java/utils/ModelParameterUtils.java
@@ -57,9 +57,13 @@ public final class ModelParameterUtils {
 
         final Map<String, String> defaultValues = getDefaultModelParameterValues(algorithm);
         final MapDifference<String, String> difference = Maps.difference(defaultValues, newParams);
+        final Map<String, String> rightParamsFromEntriesInCommon = difference.entriesDiffering().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, a -> a.getValue().rightValue()));
+
         final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
         builder.putAll(difference.entriesOnlyOnLeft());
-        builder.putAll(newParams);
+        builder.putAll(difference.entriesInCommon());
+        builder.putAll(rightParamsFromEntriesInCommon);
 
         return builder.build();
     }

--- a/openml-java-utils/src/main/java/com/feedzai/openml/java/utils/ModelParameterUtils.java
+++ b/openml-java-utils/src/main/java/com/feedzai/openml/java/utils/ModelParameterUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.feedzai.openml.java.utils;
+
+import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
+import com.feedzai.openml.provider.descriptor.ModelParameter;
+import com.feedzai.openml.provider.descriptor.fieldtype.BooleanFieldType;
+import com.feedzai.openml.provider.descriptor.fieldtype.ChoiceFieldType;
+import com.feedzai.openml.provider.descriptor.fieldtype.FreeTextFieldType;
+import com.feedzai.openml.provider.descriptor.fieldtype.ModelParameterType;
+import com.feedzai.openml.provider.descriptor.fieldtype.NumericFieldType;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Contains utility methods to manipulate {@link ModelParameter}. This allows to retrieve the default values used for
+ * each parameter.
+ *
+ * @author Paulo Pereira (paulo.pereira@feedzai.com)
+ */
+public final class ModelParameterUtils {
+
+    /**
+     * Constructor of the utility class.
+     */
+    private ModelParameterUtils() {
+    }
+
+    /**
+     * Retrieves the effective model parameters to be used by an OpenML provider. The effective instance is retrieved
+     * after getting the values of the default model parameters, then it is merged with the new model parameters.
+     *
+     * @param algorithm The description of a Machine Learning algorithm.
+     * @param newParams The collection of new model parameters.
+     * @return The collection of effective model parameters.
+     */
+    public static Map<String, String> getEffectiveModelParameterValues(final MLAlgorithmDescriptor algorithm,
+                                                                       final Map<String, String> newParams) {
+
+        final Map<String, String> defaultValues = getDefaultModelParameterValues(algorithm);
+        final MapDifference<String, String> difference = Maps.difference(defaultValues, newParams);
+        final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        builder.putAll(difference.entriesOnlyOnLeft());
+        builder.putAll(newParams);
+
+        return builder.build();
+    }
+
+    /**
+     * Retrieves the default model parameters from a {@link MLAlgorithmDescriptor}.
+     *
+     * @param algorithm The description of a Machine Learning algorithm.
+     * @return The collection of default model parameters.
+     */
+    private static Map<String, String> getDefaultModelParameterValues(final MLAlgorithmDescriptor algorithm) {
+
+        return algorithm.getParameters().stream()
+                .collect(Collectors.toMap(
+                        ModelParameter::getName,
+                        parameter -> getModelParameterTypeDefaultValue(parameter.getFieldType())
+                ));
+    }
+
+    /**
+     * Retrieves the default value from a {@link ModelParameterType}.
+     *
+     * @param fieldType The description of a model parameter field.
+     * @return The default value of a model parameter.
+     */
+    private static String getModelParameterTypeDefaultValue(final ModelParameterType fieldType) {
+
+        if (fieldType instanceof FreeTextFieldType) {
+            final FreeTextFieldType freeTextFieldType = (FreeTextFieldType) fieldType;
+            return freeTextFieldType.getDefaultValue();
+
+        } else if (fieldType instanceof NumericFieldType) {
+            final NumericFieldType numericFieldType = (NumericFieldType) fieldType;
+            return String.valueOf(numericFieldType.getDefaultValue());
+
+        } else if (fieldType instanceof ChoiceFieldType) {
+            final ChoiceFieldType choiceFieldType = (ChoiceFieldType) fieldType;
+            return choiceFieldType.getDefaultValue();
+
+        } else if (fieldType instanceof BooleanFieldType) {
+            final BooleanFieldType booleanFieldType = (BooleanFieldType) fieldType;
+            return String.valueOf(booleanFieldType.isDefaultTrue());
+        }
+
+        throw new IllegalArgumentException(String.format("Unrecognized model parameter type [%s]", fieldType));
+    }
+}

--- a/openml-java-utils/src/test/java/com/feedzai/openml/java/utils/ModelParameterUtilsTest.java
+++ b/openml-java-utils/src/test/java/com/feedzai/openml/java/utils/ModelParameterUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.feedzai.openml.java.utils;
+
+import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
+import com.feedzai.openml.provider.descriptor.ModelParameter;
+import com.feedzai.openml.provider.descriptor.fieldtype.BooleanFieldType;
+import com.feedzai.openml.provider.descriptor.fieldtype.ChoiceFieldType;
+import com.feedzai.openml.provider.descriptor.fieldtype.FreeTextFieldType;
+import com.feedzai.openml.provider.descriptor.fieldtype.NumericFieldType;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Validates the behaviour of {@link ModelParameterUtils}.
+ */
+@RunWith(JMockit.class)
+public class ModelParameterUtilsTest {
+
+    /**
+     * Validates that effective model parameters are being correctly calculated.s
+     *
+     * @param mlAlgorithmDescriptor The mocked ML algorithm.
+     */
+    @Test
+    public final void effectiveModelParameterValues(@Mocked final MLAlgorithmDescriptor mlAlgorithmDescriptor) {
+
+        final Map<String, String> expectedParams = ImmutableMap.of(
+                "param0", "false",
+                "param2", "2.0",
+                "param3", "3",
+                "param1", "99",
+                "param5", "100"
+        );
+
+        new Expectations() {{
+            mlAlgorithmDescriptor.getParameters();
+            result = ImmutableSet.of(
+                    new ModelParameter("param0", "", "", true, new BooleanFieldType(false)),
+                    new ModelParameter("param1", "", "", true, new FreeTextFieldType("1")),
+                    new ModelParameter("param2", "", "", true, NumericFieldType.min(0d, NumericFieldType.ParameterConfigType.INT, 2d)),
+                    new ModelParameter("param3", "", "", true, new ChoiceFieldType(ImmutableSet.of("1", "2", "3"), "3"))
+            );
+        }};
+
+        final Map<String, String> effectiveParams = ModelParameterUtils.getEffectiveModelParameterValues(
+                mlAlgorithmDescriptor,
+                ImmutableMap.of(
+                        "param1", "99",
+                        "param5", "100"
+                )
+        );
+
+        assertThat(effectiveParams)
+                .as("effective model parameter values")
+                .isEqualTo(expectedParams);
+    }
+}

--- a/openml-java-utils/src/test/java/com/feedzai/openml/java/utils/ModelParameterUtilsTest.java
+++ b/openml-java-utils/src/test/java/com/feedzai/openml/java/utils/ModelParameterUtilsTest.java
@@ -52,8 +52,7 @@ public class ModelParameterUtilsTest {
                 "param0", "false",
                 "param2", "2.0",
                 "param3", "3",
-                "param1", "99",
-                "param5", "100"
+                "param1", "99"
         );
 
         new Expectations() {{
@@ -69,6 +68,7 @@ public class ModelParameterUtilsTest {
         final Map<String, String> effectiveParams = ModelParameterUtils.getEffectiveModelParameterValues(
                 mlAlgorithmDescriptor,
                 ImmutableMap.of(
+                        "param0", "false",
                         "param1", "99",
                         "param5", "100"
                 )

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <project.source>1.8</project.source>
         <junit.version>4.13.1</junit.version>
         <assertj.version>3.7.0</assertj.version>
+        <jmockit.version>1.35</jmockit.version>
         <openml-api.version>1.2.0</openml-api.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
@@ -177,6 +178,12 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jmockit</groupId>
+                <artifactId>jmockit</artifactId>
+                <version>${jmockit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Some CVEs were found in the OpenML provider of H2o.

In order to fix them the version of H2o was upgraded from 3.30.0.7 to 3.36.0.3.
That allowed to easily bump the versions of log4j to 2.17.1 and of jetty to 9.4.44.v20210927.

<!--td {border: 1px solid #ccc;}br {mso-data-placement:same-cell;}-->
CVE | Component | Version | Location | Security Riska
-- | -- | -- | -- | --
CVE-2020-27216 | jetty-client | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-continuation | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-http | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-io | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-jaas | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-proxy | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-security | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-server | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-servlet | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-servlets | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2020-27216 | jetty-util | 9.4.11.v20180605 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High
CVE-2019-17571 | log4j | 1.2.17 | ./pulse-aws/pulse/lib/com.feedzai.openml-h2o-1.1.0.jar | High

