### PR TITLE
Fix validation when training H2o models

### DIFF
--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OAlgoUtilsFactory.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OAlgoUtilsFactory.java
@@ -25,6 +25,8 @@ import com.feedzai.openml.h2o.H2OAlgorithm;
 import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
 import com.feedzai.openml.util.algorithm.MLAlgorithmEnum;
 
+import java.util.Set;
+
 /**
  * Factory class responsible for providing the correct H20 Algorithm util.
  *
@@ -70,6 +72,35 @@ public class H2OAlgoUtilsFactory {
                 return new H2OGeneralizedLinearModelUtils(schema);
             case ISOLATION_FOREST:
                 return new H2OIsolationForestUtils();
+            default:
+                final String errorMessage = String.format("Unsupported algorithm: %s", algorithmDescriptor.getAlgorithmName());
+                logger.error(errorMessage);
+                throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    /**
+     * Gets the complete collection of model parameter names for a given algorithm.
+     *
+     * @param algorithmDescriptor Descriptor for the algorithm we want the utils for.
+     * @return the model parameter names.
+     */
+    public static Set<String> getModelParameterNames(final MLAlgorithmDescriptor algorithmDescriptor) {
+        switch (getH2OAlgorithm(algorithmDescriptor)) {
+            case DISTRIBUTED_RANDOM_FOREST:
+                return H2ODrfUtils.PARAMETER_NAMES;
+            case XG_BOOST:
+                return H2OXgboostUtils.PARAMETER_NAMES;
+            case DEEP_LEARNING:
+                return H2ODeepLearningUtils.PARAMETER_NAMES;
+            case GRADIENT_BOOSTING_MACHINE:
+                return H2OGbmUtils.PARAMETER_NAMES;
+            case NAIVE_BAYES_CLASSIFIER:
+                return H2OBayesUtils.PARAMETER_NAMES;
+            case GENERALIZED_LINEAR_MODEL:
+                return H2OGeneralizedLinearModelUtils.PARAMETER_NAMES;
+            case ISOLATION_FOREST:
+                return H2OIsolationForestUtils.PARAMETER_NAMES;
             default:
                 final String errorMessage = String.format("Unsupported algorithm: %s", algorithmDescriptor.getAlgorithmName());
                 logger.error(errorMessage);

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OBayesUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OBayesUtils.java
@@ -45,7 +45,7 @@ public final class H2OBayesUtils extends AbstractSupervisedH2OAlgoUtils<NaiveBay
      * The complete collection of model parameter names of an H2O Bayes model.
      */
     public static final Set<String> PARAMETER_NAMES =
-            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.NaiveBayesParametersV3.class);
+            ParametersBuilderUtil.getAllParametersNamesFor(water.bindings.pojos.NaiveBayesParametersV3.class);
 
     /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OBayesUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OBayesUtils.java
@@ -42,6 +42,12 @@ public final class H2OBayesUtils extends AbstractSupervisedH2OAlgoUtils<NaiveBay
             ParametersBuilderUtil.getParametersFor(NaiveBayesParametersV3.class, water.bindings.pojos.NaiveBayesParametersV3.class);
 
     /**
+     * The complete collection of model parameter names of an H2O Bayes model.
+     */
+    public static final Set<String> PARAMETER_NAMES =
+            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.NaiveBayesParametersV3.class);
+
+    /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.
      */
     private static final ParamsValueSetter<NaiveBayesParametersV3> PARAMS_SETTER =

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODeepLearningUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODeepLearningUtils.java
@@ -54,6 +54,12 @@ public final class H2ODeepLearningUtils extends AbstractSupervisedH2OAlgoUtils<D
             ParametersBuilderUtil.getParametersFor(DeepLearningParametersV3.class, water.bindings.pojos.DeepLearningParametersV3.class);
 
     /**
+     * The complete collection of model parameter names of an H2O Deep Learning model.
+     */
+    public static final Set<String> PARAMETER_NAMES =
+            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.DeepLearningParametersV3.class);
+
+    /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.
      */
     private static final ParamsValueSetter<DeepLearningParametersV3> PARAMS_SETTER =

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODeepLearningUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODeepLearningUtils.java
@@ -57,7 +57,7 @@ public final class H2ODeepLearningUtils extends AbstractSupervisedH2OAlgoUtils<D
      * The complete collection of model parameter names of an H2O Deep Learning model.
      */
     public static final Set<String> PARAMETER_NAMES =
-            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.DeepLearningParametersV3.class);
+            ParametersBuilderUtil.getAllParametersNamesFor(water.bindings.pojos.DeepLearningParametersV3.class);
 
     /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODrfUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODrfUtils.java
@@ -44,7 +44,7 @@ public final class H2ODrfUtils extends AbstractSupervisedH2OAlgoUtils<DRFParamet
      * The complete collection of model parameter names of an H2O Distributed Random Forest model.
      */
     public static final Set<String> PARAMETER_NAMES =
-            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.DRFParametersV3.class);
+            ParametersBuilderUtil.getAllParametersNamesFor(water.bindings.pojos.DRFParametersV3.class);
 
     /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODrfUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2ODrfUtils.java
@@ -41,6 +41,12 @@ public final class H2ODrfUtils extends AbstractSupervisedH2OAlgoUtils<DRFParamet
             ParametersBuilderUtil.getParametersFor(DRFParametersV3.class, water.bindings.pojos.DRFParametersV3.class);
 
     /**
+     * The complete collection of model parameter names of an H2O Distributed Random Forest model.
+     */
+    public static final Set<String> PARAMETER_NAMES =
+            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.DRFParametersV3.class);
+
+    /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.
      */
     private static final ParamsValueSetter<DRFParametersV3> PARAMS_SETTER =

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGbmUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGbmUtils.java
@@ -44,7 +44,7 @@ public final class H2OGbmUtils extends AbstractSupervisedH2OAlgoUtils<GBMParamet
      * The complete collection of model parameter names of an H2O GBM model.
      */
     public static final Set<String> PARAMETER_NAMES =
-            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.GBMParametersV3.class);
+            ParametersBuilderUtil.getAllParametersNamesFor(water.bindings.pojos.GBMParametersV3.class);
 
     /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGbmUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGbmUtils.java
@@ -41,6 +41,12 @@ public final class H2OGbmUtils extends AbstractSupervisedH2OAlgoUtils<GBMParamet
             ParametersBuilderUtil.getParametersFor(GBMParametersV3.class, water.bindings.pojos.GBMParametersV3.class);
 
     /**
+     * The complete collection of model parameter names of an H2O GBM model.
+     */
+    public static final Set<String> PARAMETER_NAMES =
+            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.GBMParametersV3.class);
+
+    /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.
      */
     private static final ParamsValueSetter<GBMParametersV3> PARAMS_SETTER =

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGeneralizedLinearModelUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGeneralizedLinearModelUtils.java
@@ -73,7 +73,7 @@ public final class H2OGeneralizedLinearModelUtils extends AbstractSupervisedH2OA
      * The complete collection of model parameter names of an H2O GLM model.
      */
     public static final Set<String> PARAMETER_NAMES =
-            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.GLMParametersV3.class);
+            ParametersBuilderUtil.getAllParametersNamesFor(water.bindings.pojos.GLMParametersV3.class);
 
     /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGeneralizedLinearModelUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGeneralizedLinearModelUtils.java
@@ -70,6 +70,12 @@ public final class H2OGeneralizedLinearModelUtils extends AbstractSupervisedH2OA
                     .collect(Collectors.toSet());
 
     /**
+     * The complete collection of model parameter names of an H2O GLM model.
+     */
+    public static final Set<String> PARAMETER_NAMES =
+            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.GLMParametersV3.class);
+
+    /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.
      */
     private static final ParamsValueSetter<GLMParametersV3> PARAMS_SETTER =

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OIsolationForestUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OIsolationForestUtils.java
@@ -42,6 +42,12 @@ public class H2OIsolationForestUtils extends AbstractUnsupervisedH2OAlgoUtils<Is
             ParametersBuilderUtil.getParametersFor(IsolationForestParametersV3.class, water.bindings.pojos.IsolationForestParametersV3.class);
 
     /**
+     * The complete collection of model parameter names of an H2O Isolation forest model.
+     */
+    public static final Set<String> PARAMETER_NAMES =
+            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.IsolationForestParametersV3.class);
+
+    /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.
      */
     private static final ParamsValueSetter<IsolationForestParametersV3> PARAMS_SETTER =

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OIsolationForestUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OIsolationForestUtils.java
@@ -45,7 +45,7 @@ public class H2OIsolationForestUtils extends AbstractUnsupervisedH2OAlgoUtils<Is
      * The complete collection of model parameter names of an H2O Isolation forest model.
      */
     public static final Set<String> PARAMETER_NAMES =
-            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.IsolationForestParametersV3.class);
+            ParametersBuilderUtil.getAllParametersNamesFor(water.bindings.pojos.IsolationForestParametersV3.class);
 
     /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OXgboostUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OXgboostUtils.java
@@ -17,18 +17,15 @@
 
 package com.feedzai.openml.h2o.algos;
 
-import com.feedzai.openml.data.schema.DatasetSchema;
 import com.feedzai.openml.h2o.params.ParametersBuilderUtil;
 import com.feedzai.openml.h2o.params.ParamsValueSetter;
 import com.feedzai.openml.provider.descriptor.ModelParameter;
 
-import hex.schemas.XGBoostV3;
 import hex.schemas.XGBoostV3.XGBoostParametersV3;
 
 import hex.tree.xgboost.XGBoost;
 import java.util.Map;
 import java.util.Set;
-import water.fvec.Frame;
 
 /**
  * Utility class to hold relevant information to train H2O XGBoost models.
@@ -43,6 +40,12 @@ public class H2OXgboostUtils extends AbstractSupervisedH2OAlgoUtils<XGBoostParam
      */
     public static final Set<ModelParameter> PARAMETERS =
             ParametersBuilderUtil.getParametersFor(XGBoostParametersV3.class, water.bindings.pojos.XGBoostParametersV3.class);
+
+    /**
+     * The complete collection of model parameter names of an H2O XGBoost model.
+     */
+    public static final Set<String> PARAMETER_NAMES =
+            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.XGBoostParametersV3.class);
 
     /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OXgboostUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OXgboostUtils.java
@@ -45,7 +45,7 @@ public class H2OXgboostUtils extends AbstractSupervisedH2OAlgoUtils<XGBoostParam
      * The complete collection of model parameter names of an H2O XGBoost model.
      */
     public static final Set<String> PARAMETER_NAMES =
-            ParametersBuilderUtil.getParametersNamesFor(water.bindings.pojos.XGBoostParametersV3.class);
+            ParametersBuilderUtil.getAllParametersNamesFor(water.bindings.pojos.XGBoostParametersV3.class);
 
     /**
      * The setter capable of assigning a value of a parameter to the right H2O REST POJO field.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/params/ParametersBuilderUtil.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/params/ParametersBuilderUtil.java
@@ -124,6 +124,17 @@ public final class ParametersBuilderUtil {
     }
 
     /**
+     * Gets all the model parameter names for the given algorithm.
+     *
+     * @param paramsClass The corresponding class with fields whose values are default values for each parameter.
+     * @return all model parameter names.
+     */
+    public static Set<String> getParametersNamesFor(final Class<? extends water.bindings.pojos.ModelParametersSchemaV3> paramsClass) {
+        final Map<String, String> paramName2FieldName = getParamNameToFieldNameMapping(paramsClass);
+        return paramName2FieldName.keySet();
+    }
+
+    /**
      * Gets the parameters descriptions for the given algorithm.
      *
      * @param algorithmClass The class with the meta-description of the parameters.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/params/ParametersBuilderUtil.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/params/ParametersBuilderUtil.java
@@ -129,13 +129,15 @@ public final class ParametersBuilderUtil {
      * @param paramsClass The corresponding class with fields whose values are default values for each parameter.
      * @return all model parameter names.
      */
-    public static Set<String> getParametersNamesFor(final Class<? extends water.bindings.pojos.ModelParametersSchemaV3> paramsClass) {
+    public static Set<String> getAllParametersNamesFor(final Class<? extends water.bindings.pojos.ModelParametersSchemaV3> paramsClass) {
         final Map<String, String> paramName2FieldName = getParamNameToFieldNameMapping(paramsClass);
         return paramName2FieldName.keySet();
     }
 
     /**
-     * Gets the parameters descriptions for the given algorithm.
+     * Gets the default parameters descriptions for the given algorithm. Take into account that this method doesn't
+     * return all available parameters this because some of them are being filtered, like for example to only return
+     * parameters that use primitive data types.
      *
      * @param algorithmClass The class with the meta-description of the parameters.
      * @param paramsClass    The corresponding class with fields whose values are default values for each parameter.

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
@@ -80,6 +80,7 @@ public final class H2OAlgorithmTestParams {
                 .put("nbins", "20")
                 .put("sample_rate", "1")
                 .put("mtries", "-1")
+                .put("max_hit_ratio_k", "0")
                 .build();
     }
 

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelParamTest.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OModelParamTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.feedzai.openml.h2o;
+
+import com.feedzai.openml.h2o.algos.H2OBayesUtils;
+import com.feedzai.openml.h2o.algos.H2ODeepLearningUtils;
+import com.feedzai.openml.h2o.algos.H2ODrfUtils;
+import com.feedzai.openml.h2o.algos.H2OGbmUtils;
+import com.feedzai.openml.h2o.algos.H2OGeneralizedLinearModelUtils;
+import com.feedzai.openml.h2o.algos.H2OIsolationForestUtils;
+import com.feedzai.openml.h2o.algos.H2OXgboostUtils;
+import com.feedzai.openml.provider.descriptor.ModelParameter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * H2O Model Parameter test. Validates if H2O model parameters match the model parameter names.
+ *
+ * @author Paulo Pereira (paulo.pereira@feedzai.com)
+ */
+@RunWith(Parameterized.class)
+public class H2OModelParamTest {
+
+    /**
+     * Contains all model parameter names that can be defined in a given algorithm.
+     */
+    private final Collection<String> modelParameterNames;
+
+    /**
+     * Contains the default model parameters of a given algorithm.
+     */
+    private final Collection<ModelParameter> modelParameters;
+
+    /**
+     * Constructor.
+     *
+     * @param modelParameterNames All model parameter names.
+     * @param modelParameters     Default model parameters.
+     */
+    public H2OModelParamTest(final Collection<String> modelParameterNames,
+                             final Collection<ModelParameter> modelParameters) {
+        this.modelParameterNames = modelParameterNames;
+        this.modelParameters = modelParameters;
+    }
+
+    /**
+     * Method that sets the parametrized data to use in the tests.
+     *
+     * @return data in the form of { all model parameter names, default parameters }.
+     */
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { H2ODeepLearningUtils.PARAMETER_NAMES, H2ODeepLearningUtils.PARAMETERS },
+                { H2ODrfUtils.PARAMETER_NAMES, H2ODrfUtils.PARAMETERS },
+                { H2OGbmUtils.PARAMETER_NAMES, H2OGbmUtils.PARAMETERS },
+                { H2OBayesUtils.PARAMETER_NAMES, H2OBayesUtils.PARAMETERS },
+                { H2OXgboostUtils.PARAMETER_NAMES, H2OXgboostUtils.PARAMETERS },
+                { H2OGeneralizedLinearModelUtils.PARAMETER_NAMES, H2OGeneralizedLinearModelUtils.PARAMETERS },
+                { H2OIsolationForestUtils.PARAMETER_NAMES, H2OIsolationForestUtils.PARAMETERS }
+        });
+    }
+
+    /**
+     * Tests that the default H20 parameters are inside the complete lists of model parameters.
+     */
+    @Test
+    public final void defaultParametersInsideCompleteList() {
+        final Collection<String> defaultModelParameterNames = this.modelParameters.stream()
+                .map(ModelParameter::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(this.modelParameterNames)
+                .as("Default parameters are contained inside the complete list of parameters")
+                .containsAll(defaultModelParameterNames);
+    }
+}

--- a/openml-java-utils/src/main/java/com/feedzai/openml/java/utils/ModelParameterUtils.java
+++ b/openml-java-utils/src/main/java/com/feedzai/openml/java/utils/ModelParameterUtils.java
@@ -24,8 +24,9 @@ import com.feedzai.openml.provider.descriptor.fieldtype.FreeTextFieldType;
 import com.feedzai.openml.provider.descriptor.fieldtype.ModelParameterType;
 import com.feedzai.openml.provider.descriptor.fieldtype.NumericFieldType;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -46,19 +47,27 @@ public final class ModelParameterUtils {
      * Retrieves the effective model parameters to be used by an OpenML provider. The effective instance is retrieved
      * after getting the values of the default model parameters, then it is merged with the new model parameters.
      *
-     * @param algorithm The description of a Machine Learning algorithm.
-     * @param newParams The collection of new model parameters.
+     * @param algorithm      The description of a Machine Learning algorithm.
+     * @param parameterNames The complete list of model parameter names.
+     * @param newParams      The collection of new model parameters.
      * @return The collection of effective model parameters.
      */
     public static Map<String, String> getEffectiveModelParameterValues(final MLAlgorithmDescriptor algorithm,
+                                                                       final Set<String> parameterNames,
                                                                        final Map<String, String> newParams) {
 
         final Map<String, String> defaultValues = getDefaultModelParameterValues(algorithm);
-        return defaultValues.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        entry -> newParams.getOrDefault(entry.getKey(), entry.getValue())
-                ));
+
+        final Map<String, String> effectiveModelParameter = new HashMap<>();
+
+        defaultValues.entrySet().stream()
+                .filter(entry -> !newParams.containsKey(entry.getKey()))
+                .forEach(entry -> effectiveModelParameter.put(entry.getKey(), entry.getValue()));
+        parameterNames.stream()
+                .filter(newParams::containsKey)
+                .forEach(parameter -> effectiveModelParameter.put(parameter, newParams.get(parameter)));
+
+        return effectiveModelParameter;
     }
 
     /**

--- a/openml-java-utils/src/test/java/com/feedzai/openml/java/utils/ModelParameterUtilsTest.java
+++ b/openml-java-utils/src/test/java/com/feedzai/openml/java/utils/ModelParameterUtilsTest.java
@@ -52,6 +52,7 @@ public class ModelParameterUtilsTest {
                 "param0", "false",
                 "param2", "2.0",
                 "param3", "3",
+                "param4", "53",
                 "param1", "99"
         );
 
@@ -67,9 +68,11 @@ public class ModelParameterUtilsTest {
 
         final Map<String, String> effectiveParams = ModelParameterUtils.getEffectiveModelParameterValues(
                 mlAlgorithmDescriptor,
+                ImmutableSet.of("param0", "param1", "param2", "param3", "param4"),
                 ImmutableMap.of(
                         "param0", "false",
                         "param1", "99",
+                        "param4", "53",
                         "param5", "100"
                 )
         );


### PR DESCRIPTION
The previous commit https://github.com/feedzai/feedzai-openml-java/pull/102 introduced a bug where the it was only possible to configure model parameters if they were inside the collection of default model parameters.
This caused a problem because the collection of default model parameters doesn't include all possible model parameters, because some are being filtered due to unsupported types and other reasons.

That problem is now fixed by having a second collection with the names of all possible model parameters, that is then used to get the effective model parameters to be used by the H2o provider.