### PR TITLE
Fix unrecognized format specifier when training xgboost models

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -234,18 +234,26 @@
                                         <!-- The following two libraries were removed because they were under-performing in cluster environments-->
                                         <exclude>**/libxgboost4j_gpu.so</exclude>
                                         <exclude>**/libxgboost4j_omp.so</exclude>
-                                        <!-- Exclude Log4j2Plugins.dat cache file so that Log4j scans for plugins on startup (https://issues.apache.org/jira/browse/LOG4J2-673) -->
-                                        <exclude>**/Log4j2Plugins.dat</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <!-- Concatenates Log4j2Plugins.dat files in order to provide a workaround for LOG4J2-673 and LOG4J2-954 -->
+                                <transformer
+                                        implementation="io.github.edwgiz.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
                             </transformers>
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.github.edwgiz</groupId>
+                        <artifactId>log4j-maven-shade-plugin-extensions</artifactId>
+                        <version>2.17.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <!-- allow to use the objects created in test directory from outside of this module -->
             <plugin>
@@ -261,6 +269,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.2.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The fix merged in [108](https://github.com/feedzai/feedzai-openml-java/pull/108) caused a random failure when training xgboost models.
The failure was also caused by the bump of log4j and most likely is due to different versions being picked first by the Java class loader.
The solution was to go back to the initial solution proposed in the PR mentioned above. 