### PR TITLE
ref RAILGUN-930 openml-h2o: Revert "Remove kotlin dependency from the shaded jar (#60)"

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -265,7 +265,6 @@
                                         <exclude>org/slf4j/**</exclude>
                                         <exclude>com/esotericsoftware/kryo/**</exclude>
                                         <exclude>org/objenesis/**</exclude>
-                                        <exclude>kotlin/**</exclude>
                                         <!-- The following two libraries were removed because they were under-performing in cluster environments-->
                                         <exclude>**/libxgboost4j_gpu.so</exclude>
                                         <exclude>**/libxgboost4j_omp.so</exclude>


### PR DESCRIPTION
This commit reverts the shaded Kotlin removal.