### PR TITLE
updated since tags to version 1.4.0

### DIFF
--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/FairGBMDescriptorUtil.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/FairGBMDescriptorUtil.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * Utility to organize all the necessary Machine Learning Hyper-Parameters for configuring the training of LightGBM.
  *
  * @author Andre Cruz (andre.cruz@feedzai.com)
- * @since 1.3.6
+ * @since 1.4.0
  */
 public class FairGBMDescriptorUtil extends LightGBMDescriptorUtil {
 

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/FairGBMMLProvider.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/FairGBMMLProvider.java
@@ -30,7 +30,7 @@ import com.feedzai.openml.util.algorithm.MLAlgorithmEnum;
  * This class implements Feedzai's OpenML MachineLearningProvider interface for FairGBM (constrained LightGBM).
  *
  * @author Andre Cruz (andre.cruz@feedzai.com)
- * @since 1.3.6
+ * @since 1.4.0
  */
 @AutoService(MachineLearningProvider.class)
 public class FairGBMMLProvider implements TrainingMachineLearningProvider<LightGBMModelCreator> {

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/FairGBMParamParserUtil.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/FairGBMParamParserUtil.java
@@ -16,7 +16,7 @@ import static com.feedzai.openml.provider.lightgbm.FairGBMDescriptorUtil.CONSTRA
  * Utility to parse parameters specific to the FairGBM model.
  *
  * @author Andre Cruz (andre.cruz@feedzai.com)
- * @since 1.3.6
+ * @since 1.4.0
  */
 public class FairGBMParamParserUtil {
 

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/DescriptorUtilTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/DescriptorUtilTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
  * Tests for the descriptor util classes (both FairGBM and LightGBM).
  *
  * @author Andre Cruz (andre.cruz@feedzai.com)
- * @since 1.3.6
+ * @since 1.4.0
  */
 public class DescriptorUtilTest {
 

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/FairGBMBinaryClassificationModelTrainerTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/FairGBMBinaryClassificationModelTrainerTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for using the LightGBMBinaryClassificationModelTrainer class with FairGBM.
  *
  * @author Andre Cruz (andre.cruz@feedzai.com)
- * @since 1.3.6
+ * @since 1.4.0
  */
 public class FairGBMBinaryClassificationModelTrainerTest {
 

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/FairGBMParamParserUtilTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/FairGBMParamParserUtilTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for the FairGBMParamParserUtil class.
  *
  * @author Andre Cruz (andre.cruz@feedzai.com)
- * @since 1.3.6
+ * @since 1.4.0
  */
 public class FairGBMParamParserUtilTest {
 

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/GBMProvidersTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/GBMProvidersTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Conversely, it guarantees that no fairness-aware algorithm is used with LightGBMMLProvider.
  *
  * @author Sérgio Jesus (sergio.jesus@feedzai.com)
- * @since 1.3.6
+ * @since 1.4.0
  */
 public class GBMProvidersTest {
 


### PR DESCRIPTION
All FairGBM files should say "since version 1.4.0" instead of "since version 1.3.6"