### PR TITLE
Pin FairGBM artifact version to fairgbm-v1.0.0

### DIFF
--- a/openml-lightgbm/lightgbm-builder/pom.xml
+++ b/openml-lightgbm/lightgbm-builder/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>com.feedzai.openml.lightgbm</groupId>
     <artifactId>lightgbm-lib</artifactId>
-    <version>v3.2.1-fairgbm-alpha</version>
+    <version>fairgbm-v1.0.0</version>
 
     <packaging>jar</packaging>
     <name>Openml LightGBM lib</name>
@@ -33,8 +33,8 @@
         <!-- Feedzai's FairGBM! -->
         <lightgbm.repo.url>https://github.com/feedzai/fairgbm.git</lightgbm.repo.url>
 
-        <lightgbm.version>main-fairgbm</lightgbm.version>
-        <lightgbmlib.version>v3.2.1-fairgbm-alpha</lightgbmlib.version>
+        <lightgbm.version>fairgbm-v1.0.0</lightgbm.version>
+        <lightgbmlib.version>fairgbm-v1.0.0</lightgbmlib.version>
     </properties>
 
     <build>

--- a/openml-lightgbm/lightgbm-provider/pom.xml
+++ b/openml-lightgbm/lightgbm-provider/pom.xml
@@ -25,7 +25,7 @@
     <description>OpenML LightGBM Machine Learning Model and Classifier provider</description>
 
     <properties>
-        <lightgbmlib.version>v3.2.1-fairgbm-alpha</lightgbmlib.version>
+        <lightgbmlib.version>fairgbm-v1.0.0</lightgbmlib.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
We were using the main fairgbm branch, `main-fairgbm`; but we should be using a  pinned version.

We are now using the tagged version of FairGBM, `fairgbm-v1.0.0` (pointing to the exact same commit as previously -- the current HEAD of `main-fairgbm`).