### PR TITLE
Document experimental releases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,23 @@ mvn clean install
 
 ## Releasing
 
-For all releases, as the hotfix branch is ready all that's needed to actually release is to create an annotated tag pointing to the hotfix branch head (example below for releasing version 1.2.29):
+For all releases, as the hotfix branch is ready all that's needed to actually release is to create an annotated tag pointing to the hotfix branch head.
 
+### Public Release
+
+For a public release you need to create and push an annotated tag. See the example below for releasing version 1.2.29:
 ```bash
-# Ensure the tag is made on the udpated branch
+# Ensure the tag is made on the updated branch
 git fetch -a
 git checkout origin/hf-1.2.X
 git tag -a 1.2.29
 # Your EDITOR will open. Write a good message and save as it is used on Github as a release message
 git push origin 1.2.29
 ```
-Then you need to [create a new release](https://github.com/feedzai/feedzai-openml-java/releases/new) with this tag and the description according [to the previous ones](https://github.com/feedzai/feedzai-openml-java/releases).
+Then you need to [create a new release](https://github.com/feedzai/feedzai-openml-java/releases/new) with this tag.
+There is a "Generate release notes" button available to create the release notes, just organize them according [to the previous ones](https://github.com/feedzai/feedzai-openml-java/releases).
 
-### Releasing an Experimental
+### Experimental Release
 
 For experimental releases, the process is the same as above but with a lightweight tag instead of annotated.
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ git push origin 1.2.29
 ```
 Then you need to [create a new release](https://github.com/feedzai/feedzai-openml-java/releases/new) with this tag and the description according [to the previous ones](https://github.com/feedzai/feedzai-openml-java/releases).
 
+### Releasing an Experimental
+
+For experimental releases, the process is the same as above but with a lightweight tag instead of annotated.
+```bash
+#the xp part is not needed, what matters is that the tag is not annotated, but is a good indicator for others that this was a tag for an experimental release
+git tag 1.5.0-xp 
+git push origin 1.5.0-xp
+```
+
 ## Modules
 
 ### H2O


### PR DESCRIPTION
Due to a problem/mistake releasing the experimental for version 1.4.1, version 1.4.9999 was released instead of 1.4.9999-snapshot.

This commit documents the proper way of releasing experimentals for this repository so that the same situation does not happen in the future.