### PR TITLE
Fixed pinned FairGBM tag to v0.1.0

### DIFF
--- a/openml-lightgbm/lightgbm-builder/pom.xml
+++ b/openml-lightgbm/lightgbm-builder/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>com.feedzai.openml.lightgbm</groupId>
     <artifactId>lightgbm-lib</artifactId>
-    <version>fairgbm-v1.0.0</version>
+    <version>v0.1.0</version>
 
     <packaging>jar</packaging>
     <name>Openml LightGBM lib</name>
@@ -33,8 +33,8 @@
         <!-- Feedzai's FairGBM! -->
         <lightgbm.repo.url>https://github.com/feedzai/fairgbm.git</lightgbm.repo.url>
 
-        <lightgbm.version>fairgbm-v1.0.0</lightgbm.version>
-        <lightgbmlib.version>fairgbm-v1.0.0</lightgbmlib.version>
+        <lightgbm.version>v0.1.0</lightgbm.version>
+        <lightgbmlib.version>v0.1.0</lightgbmlib.version>
     </properties>
 
     <build>

--- a/openml-lightgbm/lightgbm-provider/pom.xml
+++ b/openml-lightgbm/lightgbm-provider/pom.xml
@@ -25,7 +25,7 @@
     <description>OpenML LightGBM Machine Learning Model and Classifier provider</description>
 
     <properties>
-        <lightgbmlib.version>fairgbm-v1.0.0</lightgbmlib.version>
+        <lightgbmlib.version>v0.1.0</lightgbmlib.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
We changed the FairGBM tag/release versioning such that all LightGBM-related tags were deleted and new tags will start from v0.1.0.

This tag `v0.1.0` currently points to the code-base that is slightly behind the FairGBM main branch but is exactly the same as it was in the previous `fairgbm-v1.0.0` tag. This way no issues should occur.