### PR TITLE
openml-lightgbm: fix scores and contributions test precision

### DIFF
--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMResultTest.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/LightGBMResultTest.java
@@ -236,7 +236,7 @@ public class LightGBMResultTest {
                     .isEqualTo(2);
 
             final double prediction = resultInstance.getValue(9);
-            final Offset<Double> offset = Offset.offset(1.0e-16);
+            final Offset<Double> offset = Offset.offset(1.0e-15);
 
             assertThat(scoreDistribution[1])
                     .as("The score should be expected.")


### PR DESCRIPTION
In ARM we're already having issues with the precision in the tests as reported by Artur Pedroso:

![image](https://github.com/feedzai/feedzai-openml-java/assets/3976753/71c52f28-9882-47f4-9ea3-226cd51f5085)


Test `ensureLightgbmScoresAndContributions` failed with an error of ~2.2E-16.

In principle IEEE-754 doubles only guarantee 15 decimal digits of precision, so we lowered the required test precision from 1E-16 to 1E-15.