### PR TITLE
Add support for Alpine on LGBM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run tests on Alpine docker
         run: |
-          docker run --rm -t -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
+          docker run --rm -t -v ~/.m2:/root/.m2 -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
           /bin/sh -c 'apk add clang openjdk8 maven bash git && \
           git config --global --add safe.directory /feedzai-openml-java && \
           git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
@@ -61,7 +61,13 @@ jobs:
 
       # The skipped tests is because h2o-xgboost isn't ready to use on arm64
       - name: Test on arm64
-        run: docker run --rm --platform=arm64 -t -v ~/.m2:/root/.m2 -v $(pwd):/feedzai-openml-java maven:3.8-openjdk-8-slim /bin/bash -c 'apt update && apt install -y --no-install-recommends git && git config --global --add safe.directory /feedzai-openml-java && git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && cd /feedzai-openml-java && mvn test -B -DfailIfNoTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
+        run: |
+          docker run --rm --platform=arm64 -t -v ~/.m2:/root/.m2 -v $(pwd):/feedzai-openml-java maven:3.8-openjdk-8-slim \
+          /bin/bash -c 'apt update && apt install -y --no-install-recommends git && \
+          git config --global --add safe.directory /feedzai-openml-java && \
+          git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
+          cd /feedzai-openml-java && \
+          mvn test -B -DfailIfNoTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ jobs:
 
       - name: Build and test
         run: mvn test -B
+        # skip build arm temporarily to speedup tests
+        env:
+          ARCH_BUILD: "single"
 
       - name: Run tests on Alpine docker
         run: |
@@ -56,8 +59,11 @@ jobs:
           git config --global --add safe.directory /feedzai-openml-java && \
           git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
           cd /feedzai-openml-java && \
-          cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/alpine/lib_lightgbm.so /lib/lib_lightgbm.so && \
+          cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/musl/lib_lightgbm.so /lib/lib_lightgbm.so && \
           mvn test -B'
+        # skip build arm temporarily to speedup tests
+        env:
+          ARCH_BUILD: "single"
 
       # The skipped tests is because h2o-xgboost isn't ready to use on arm64
       - name: Test on arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
           cd /feedzai-openml-java && \
           cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/musl/lib_lightgbm.so /lib/lib_lightgbm.so && \
-          mvn test -B -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
+          mvn test -B -Dsurefire.failIfNoSpecifiedTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
         # skip build arm temporarily to speedup tests
         env:
           ARCH_BUILD: "single"
@@ -74,7 +74,7 @@ jobs:
           git config --global --add safe.directory /feedzai-openml-java && \
           git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
           cd /feedzai-openml-java && \
-          mvn test -B -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
+          mvn test -B -Dsurefire.failIfNoSpecifiedTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           ARCH_BUILD: "single"
 
+      # The skipped tests is because h2o-xgboost isn't ready to use on arm64
       - name: Run tests on Alpine docker
         run: |
           docker run --rm -t -v ~/.m2:/root/.m2 -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
@@ -60,7 +61,7 @@ jobs:
           git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
           cd /feedzai-openml-java && \
           cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/musl/lib_lightgbm.so /lib/lib_lightgbm.so && \
-          mvn test -B'
+          mvn test -B -DfailIfNoTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
         # skip build arm temporarily to speedup tests
         env:
           ARCH_BUILD: "single"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,27 +49,6 @@ jobs:
       - name: Build and test
         run: mvn test -B
 
-      # The skipped tests is because h2o-xgboost isn't ready to use on arm64
-      - name: Test on arm64
-        run: docker run --rm --platform=arm64 -t -v ~/.m2:/root/.m2 -v $(pwd):/feedzai-openml-java maven:3.8-openjdk-8-slim /bin/bash -c 'apt update && apt install -y --no-install-recommends git && git config --global --add safe.directory /feedzai-openml-java && git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && cd /feedzai-openml-java && mvn test -B -DfailIfNoTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
-
-      - uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
-
-  build_alpine:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - run: |
-          git fetch -f --tags
-          echo exit code $?
-          git tag --list
-
       - name: Run tests on Alpine docker
         run: |
           docker run --rm -t -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
@@ -80,3 +59,11 @@ jobs:
           mvn clean install -B -DskipTests && \
           cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/alpine/lib_lightgbm.so /lib/lib_lightgbm.so && \
           mvn test -B'
+
+      # The skipped tests is because h2o-xgboost isn't ready to use on arm64
+      - name: Test on arm64
+        run: docker run --rm --platform=arm64 -t -v ~/.m2:/root/.m2 -v $(pwd):/feedzai-openml-java maven:3.8-openjdk-8-slim /bin/bash -c 'apt update && apt install -y --no-install-recommends git && git config --global --add safe.directory /feedzai-openml-java && git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && cd /feedzai-openml-java && mvn test -B -DfailIfNoTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
+
+      - uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build and test
         run: mvn test -B
 
-      # The skipped tests is because h2o-xgboost isn't ready to use on arm64
+      # The skipped tests is because h2o-xgboost isn't ready to use with musl
       - name: Test with musl
         run: |
           docker run --rm -t -v ~/.m2:/root/.m2 -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,8 @@ jobs:
           git tag --list
 
       - name: Run tests on Alpine docker
-        run: docker run --rm -t -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
+        run: |
+          docker run --rm -t -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
           /bin/sh -c 'apk add clang openjdk8 maven bash && \
           cd /feedzai-openml-java && \
           mvn clean install -DskipTests && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,6 @@ jobs:
           git config --global --add safe.directory /feedzai-openml-java && \
           git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
           cd /feedzai-openml-java && \
-          mvn clean install -B -DskipTests && \
           cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/alpine/lib_lightgbm.so /lib/lib_lightgbm.so && \
           mvn test -B'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,28 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
+
+  build_alpine:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: |
+          git fetch -f --tags
+          echo exit code $?
+          git tag --list
+
+      - name: Run tests on Alpine docker
+        run: docker run --rm -t -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
+          /bin/sh -c 'apk add clang openjdk8 maven bash && \
+          cd /feedzai-openml-java && \
+          mvn clean install -DskipTests && \
+          cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/alpine/lib_lightgbm.so /lib/lib_lightgbm.so && \
+          mvn surefire:test -pl :openml-lightgbm,:openml-datarobot'
+
+      - uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
           cd /feedzai-openml-java && \
           cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/musl/lib_lightgbm.so /lib/lib_lightgbm.so && \
-          mvn test -B -DfailIfNoTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
+          mvn test -B -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
         # skip build arm temporarily to speedup tests
         env:
           ARCH_BUILD: "single"
@@ -74,7 +74,7 @@ jobs:
           git config --global --add safe.directory /feedzai-openml-java && \
           git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
           cd /feedzai-openml-java && \
-          mvn test -B -DfailIfNoTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
+          mvn test -B -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,12 +73,10 @@ jobs:
       - name: Run tests on Alpine docker
         run: |
           docker run --rm -t -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
-          /bin/sh -c 'apk add clang openjdk8 maven bash && \
+          /bin/sh -c 'apk add clang openjdk8 maven bash git && \
+          git config --global --add safe.directory /feedzai-openml-java && \
+          git config --global --add safe.directory /feedzai-openml-java/openml-lightgbm/lightgbm-builder/make-lightgbm && \
           cd /feedzai-openml-java && \
-          mvn clean install -DskipTests && \
+          mvn clean install -B -DskipTests && \
           cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/alpine/lib_lightgbm.so /lib/lib_lightgbm.so && \
-          mvn surefire:test -pl :openml-lightgbm,:openml-datarobot'
-
-      - uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
+          mvn test -B'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,12 +48,9 @@ jobs:
 
       - name: Build and test
         run: mvn test -B
-        # skip build arm temporarily to speedup tests
-        env:
-          ARCH_BUILD: "single"
 
       # The skipped tests is because h2o-xgboost isn't ready to use on arm64
-      - name: Run tests on Alpine docker
+      - name: Test with musl
         run: |
           docker run --rm -t -v ~/.m2:/root/.m2 -v $(pwd):/feedzai-openml-java -e FDZ_OPENML_JAVA_LIBC="musl" alpine:3.18.4 \
           /bin/sh -c 'apk add clang openjdk8 maven bash git && \
@@ -62,9 +59,6 @@ jobs:
           cd /feedzai-openml-java && \
           cp openml-lightgbm/lightgbm-builder/make-lightgbm/build/amd64/musl/lib_lightgbm.so /lib/lib_lightgbm.so && \
           mvn test -B -Dsurefire.failIfNoSpecifiedTests=false -Dtest=!ClassifyUnknownCategoryTest#test,!H2OModelProviderTrainTest#trainModelsForAllAlgorithms'
-        # skip build arm temporarily to speedup tests
-        env:
-          ARCH_BUILD: "single"
 
       # The skipped tests is because h2o-xgboost isn't ready to use on arm64
       - name: Test on arm64

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ If the build fails compiling for ARM64 you may need to run:
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ```
 
+To use the models on Operating Systems with musl (supported only for AMD64 architectures), the ENV variable `FDZ_OPENML_JAVA_LIBC`
+must be set to `musl`.  This variable can take the values `glibc` and `musl`. H2O-xgboost can't be used with musl.
+
 ## Releasing
 
 For all releases, as the hotfix branch is ready all that's needed to actually release is to create an annotated tag pointing to the hotfix branch head.

--- a/openml-lightgbm/lightgbm-builder/pom.xml
+++ b/openml-lightgbm/lightgbm-builder/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>com.feedzai.openml.lightgbm</groupId>
     <artifactId>lightgbm-lib</artifactId>
-    <version>v0.1.0</version>
+    <version>v0.9.14</version>
 
     <packaging>jar</packaging>
     <name>Openml LightGBM lib</name>
@@ -33,8 +33,8 @@
         <!-- Feedzai's FairGBM! -->
         <lightgbm.repo.url>https://github.com/feedzai/fairgbm.git</lightgbm.repo.url>
 
-        <lightgbm.version>v0.1.0</lightgbm.version>
-        <lightgbmlib.version>v0.1.0</lightgbmlib.version>
+        <lightgbm.version>v0.9.14</lightgbm.version>
+        <lightgbmlib.version>v0.9.14</lightgbmlib.version>
     </properties>
 
     <build>

--- a/openml-lightgbm/lightgbm-provider/pom.xml
+++ b/openml-lightgbm/lightgbm-provider/pom.xml
@@ -25,7 +25,7 @@
     <description>OpenML LightGBM Machine Learning Model and Classifier provider</description>
 
     <properties>
-        <lightgbmlib.version>v0.1.0</lightgbmlib.version>
+        <lightgbmlib.version>v0.9.14</lightgbmlib.version>
     </properties>
 
     <dependencies>

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
@@ -38,22 +38,16 @@ public class Infrastructure {
      */
     public String getLgbmNativeLibsFolder() throws IOException {
 
-        final String libraryPath;
         switch (cpuArchitecture) {
             case AARCH64:
                 if (libcImpl == LibcImplementation.MUSL) {
                     throw new IOException("Trying to use LightGBM on a musl-based OS with unsupported arm64 architecture.");
                 }
-                libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/";
-                break;
+                return cpuArchitecture.getLgbmNativeLibsFolder() + "/";
             case AMD64:
-
-                libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/" + libcImpl.getLibcImpl() + "/";
-                break;
+                return cpuArchitecture.getLgbmNativeLibsFolder() + "/" + libcImpl.getLibcImpl() + "/";
             default:
                 throw new IllegalStateException("Unexpected value: " + cpuArchitecture);
         }
-
-        return libraryPath;
     }
 }

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
@@ -1,0 +1,47 @@
+package com.feedzai.openml.provider.lightgbm;
+
+import java.io.IOException;
+
+/**
+ * Enum that represents the infrastructure where code is running and consequent lgbm native libs locations.
+ */
+public class Infrastructure {
+
+    /**
+     * The CPU architecture used.
+     */
+    private final CpuArchitecture cpuArchitecture;
+
+    /**
+     * The libc implementation available.
+     */
+    private final LibcImplementation libcImpl;
+
+    public Infrastructure(CpuArchitecture cpuArchitecture, LibcImplementation libcImpl) {
+        this.cpuArchitecture = cpuArchitecture;
+        this.libcImpl = libcImpl;
+    }
+
+    /**
+     * Gets the native libraries folder name according to the cpu architecture.
+     *
+     * @return the native libraries folder name according to the cpu architecture.
+     */
+    public String getLgbmNativeLibsFolder() throws IOException {
+
+
+        if (libcImpl == LibcImplementation.MUSL && cpuArchitecture == CpuArchitecture.AARCH64) {
+            throw new IOException("Trying to use LightGBM on a musl-based OS with unsupported arm64 architecture.");
+        }
+
+        final String libraryPath;
+        if (cpuArchitecture == CpuArchitecture.AARCH64) {
+            libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/";
+        }
+        else {
+            libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/" + libcImpl.getLibcImpl() + "/";
+        }
+
+        return libraryPath;
+    }
+}

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
@@ -2,6 +2,7 @@ package com.feedzai.openml.provider.lightgbm;
 
 import java.io.IOException;
 
+
 /**
  * Enum that represents the infrastructure where code is running and consequent lgbm native libs locations.
  */
@@ -17,18 +18,21 @@ public class Infrastructure {
      */
     private final LibcImplementation libcImpl;
 
-    public Infrastructure(CpuArchitecture cpuArchitecture, LibcImplementation libcImpl) {
+    public Infrastructure(final CpuArchitecture cpuArchitecture, final LibcImplementation libcImpl) {
         this.cpuArchitecture = cpuArchitecture;
         this.libcImpl = libcImpl;
     }
 
+    public String toString() {
+        return cpuArchitecture.getLgbmNativeLibsFolder() + " architecture with " + libcImpl.getLibcImpl() + " libc implementation";
+    }
+
     /**
-     * Gets the native libraries folder name according to the cpu architecture.
+     * Gets the native libraries folder name according to the cpu architecture and libc implementation.
      *
-     * @return the native libraries folder name according to the cpu architecture.
+     * @return the native libraries folder name.
      */
     public String getLgbmNativeLibsFolder() throws IOException {
-
 
         if (libcImpl == LibcImplementation.MUSL && cpuArchitecture == CpuArchitecture.AARCH64) {
             throw new IOException("Trying to use LightGBM on a musl-based OS with unsupported arm64 architecture.");

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
@@ -30,8 +30,6 @@ public class Infrastructure {
                 ", libcImpl=" + libcImpl +
                 '}';
     }
-        return cpuArchitecture.getLgbmNativeLibsFolder() + " architecture with " + libcImpl.getLibcImpl() + " libc implementation";
-    }
 
     /**
      * Gets the native libraries folder name according to the cpu architecture and libc implementation.

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
@@ -23,7 +23,13 @@ public class Infrastructure {
         this.libcImpl = libcImpl;
     }
 
+    @Override
     public String toString() {
+        return "Infrastructure{" +
+                "cpuArchitecture=" + cpuArchitecture +
+                ", libcImpl=" + libcImpl +
+                '}';
+    }
         return cpuArchitecture.getLgbmNativeLibsFolder() + " architecture with " + libcImpl.getLibcImpl() + " libc implementation";
     }
 

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/Infrastructure.java
@@ -38,16 +38,20 @@ public class Infrastructure {
      */
     public String getLgbmNativeLibsFolder() throws IOException {
 
-        if (libcImpl == LibcImplementation.MUSL && cpuArchitecture == CpuArchitecture.AARCH64) {
-            throw new IOException("Trying to use LightGBM on a musl-based OS with unsupported arm64 architecture.");
-        }
-
         final String libraryPath;
-        if (cpuArchitecture == CpuArchitecture.AARCH64) {
-            libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/";
-        }
-        else {
-            libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/" + libcImpl.getLibcImpl() + "/";
+        switch (cpuArchitecture) {
+            case AARCH64:
+                if (libcImpl == LibcImplementation.MUSL) {
+                    throw new IOException("Trying to use LightGBM on a musl-based OS with unsupported arm64 architecture.");
+                }
+                libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/";
+                break;
+            case AMD64:
+
+                libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/" + libcImpl.getLibcImpl() + "/";
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + cpuArchitecture);
         }
 
         return libraryPath;

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LibcImplementation.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LibcImplementation.java
@@ -1,0 +1,27 @@
+package com.feedzai.openml.provider.lightgbm;
+
+/**
+ * Enum that represents the libc implementation available on the machine and consequent lgbm native libs locations.
+ */
+public enum LibcImplementation {
+    MUSL("musl"),
+    GLIBC("glibc");
+
+    /**
+     * This is the name of available libc implementation and indicates the folder where the lightgbm native libraries are.
+     */
+    private final String libcImpl;
+
+    LibcImplementation(final String libcImpl){
+        this.libcImpl = libcImpl;
+    }
+
+    /**
+     * Gets the native libraries folder name according to the libc implementation.
+     *
+     * @return the native libraries folder name according to the libc implementation.
+     */
+    public String getLibcImpl() {
+        return libcImpl;
+    }
+}

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
@@ -49,7 +49,7 @@ public class LightGBMUtils {
     /**
      * Environment variable with the implementation of libc available on the system.
      */
-    static final String FDZ_OPENML_JAVA_LIBC = "FDZ_OPENML_JAVA_LIBC";
+    private static final String FDZ_OPENML_JAVA_LIBC = "FDZ_OPENML_JAVA_LIBC";
 
     /**
      * State variable to know if it loadLibs was ever called.

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
@@ -128,8 +128,8 @@ public class LightGBMUtils {
 
         final String libraryPath;
         if (cpuArchitecture.getLgbmNativeLibsFolder().equals("amd64") && isAlpine) {
-            logger.debug("Loading LightGBM shared lib: {} for {} on Alpine.", sharedLibResourceName, cpuArchitecture);
-            libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/alpine/" + sharedLibResourceName;
+            logger.debug("Loading LightGBM shared lib: {} for {} on Alpine with musl.", sharedLibResourceName, cpuArchitecture);
+            libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/musl/" + sharedLibResourceName;
         }
         else if (cpuArchitecture.getLgbmNativeLibsFolder().equals("amd64")) {
             logger.debug("Loading LightGBM shared lib: {} for {}.", sharedLibResourceName, cpuArchitecture);

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
@@ -90,7 +90,7 @@ public class LightGBMUtils {
         }
     }
 
-    static LibcImplementation getLibcImplementation(final String libcImpl) {
+    protected static LibcImplementation getLibcImplementation(final String libcImpl) {
         if (libcImpl == null || libcImpl.isEmpty()) {
             logger.debug("{} not set, assuming glibc as libc implementation.", FDZ_OPENML_JAVA_LIBC);
             return LibcImplementation.GLIBC;

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
@@ -127,9 +127,13 @@ public class LightGBMUtils {
         }
 
         final String libraryPath;
-        if (isAlpine) {
+        if (cpuArchitecture.getLgbmNativeLibsFolder().equals("amd64") && isAlpine) {
             logger.debug("Loading LightGBM shared lib: {} for {} on Alpine.", sharedLibResourceName, cpuArchitecture);
-            libraryPath = "alpine/" + sharedLibResourceName;
+            libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/alpine/" + sharedLibResourceName;
+        }
+        else if (cpuArchitecture.getLgbmNativeLibsFolder().equals("amd64")) {
+            logger.debug("Loading LightGBM shared lib: {} for {}.", sharedLibResourceName, cpuArchitecture);
+            libraryPath = cpuArchitecture.getLgbmNativeLibsFolder() + "/glibc/" + sharedLibResourceName;
         }
         else {
             logger.debug("Loading LightGBM shared lib: {} for {}.", sharedLibResourceName, cpuArchitecture);

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
@@ -47,6 +47,11 @@ public class LightGBMUtils {
     static final int BINARY_LGBM_NUM_CLASSES = 1;
 
     /**
+     * Environment variable with the implementation of libc available on the system.
+     */
+    static final String FDZ_OPENML_JAVA_LIBC = "FDZ_OPENML_JAVA_LIBC";
+
+    /**
      * State variable to know if it loadLibs was ever called.
      */
     private static boolean libsLoaded = false;
@@ -60,7 +65,7 @@ public class LightGBMUtils {
 
         if (!libsLoaded) {
             final CpuArchitecture cpuArchitecture = getCpuArchitecture(System.getProperty("os.arch"));
-            final LibcImplementation libcImpl = getLibcImplementation(System.getenv("FDZ_OPENML_JAVA_LIBC"));
+            final LibcImplementation libcImpl = getLibcImplementation(System.getenv(FDZ_OPENML_JAVA_LIBC));
             final Infrastructure infrastructure = new Infrastructure(cpuArchitecture, libcImpl);
 
             try {
@@ -87,7 +92,7 @@ public class LightGBMUtils {
 
     static LibcImplementation getLibcImplementation(final String libcImpl) {
         if (libcImpl == null || libcImpl.isEmpty()) {
-            logger.debug("FDZ_OPENML_JAVA_LIBC not set, assuming glibc as libc implementation.");
+            logger.debug("{} not set, assuming glibc as libc implementation.", FDZ_OPENML_JAVA_LIBC);
             return LibcImplementation.GLIBC;
         }
 

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMUtils.java
@@ -86,10 +86,13 @@ public class LightGBMUtils {
     }
 
     static LibcImplementation getLibcImplementation(final String libcImpl) {
-        if (libcImpl == null || libcImpl.isEmpty()) return LibcImplementation.GLIBC;
+        if (libcImpl == null || libcImpl.isEmpty()) {
+            logger.debug("FDZ_OPENML_JAVA_LIBC not set, assuming glibc as libc implementation.");
+            return LibcImplementation.GLIBC;
+        }
 
         try {
-            return LibcImplementation.valueOf(libcImpl.toUpperCase());
+            return LibcImplementation.valueOf(libcImpl.toUpperCase().trim());
         } catch (final IllegalArgumentException ex) {
             logger.error("Trying to use LightGBM with an unsupported libc implementation {}.", libcImpl, ex);
             throw ex;
@@ -108,6 +111,7 @@ public class LightGBMUtils {
             final Infrastructure infrastructure
     ) throws IOException {
 
+        logger.debug("Loading LightGBM shared lib: {} for {}.", sharedLibResourceName, infrastructure);
         final String libraryPath = infrastructure.getLgbmNativeLibsFolder() + sharedLibResourceName;
 
         final InputStream inputStream = LightGBMUtils.class.getClassLoader()

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestInfrastructure.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestInfrastructure.java
@@ -1,0 +1,45 @@
+/*
+ * The copyright of this file belongs to Feedzai. The file cannot be
+ * reproduced in whole or in part, stored in a retrieval system,
+ * transmitted in any form, or by any means electronic, mechanical,
+ * photocopying, or otherwise, without the prior permission of the owner.
+ *
+ * © 2023 Feedzai, Strictly Confidential
+ */
+package com.feedzai.openml.provider.lightgbm;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Tests the retrieval of native libs folder path for Infrastructure.
+ *
+ * @author Renato Azevedo (renato.azevedo@feedzai.com)
+ */
+public class TestInfrastructure {
+    @Test
+    public void unknownInfrastructureCombination() {
+        Infrastructure infrastructure = new Infrastructure(CpuArchitecture.AARCH64, LibcImplementation.MUSL);
+
+        Assertions.assertThatThrownBy(infrastructure::getLgbmNativeLibsFolder)
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void knowsCorrectInfrastructureCombination() throws IOException {
+
+        Infrastructure infra_arm64_glibc = new Infrastructure(CpuArchitecture.AARCH64, LibcImplementation.GLIBC);
+        Assertions.assertThat(infra_arm64_glibc.getLgbmNativeLibsFolder())
+                .isEqualTo("arm64/");
+
+        Infrastructure infra_amd64_glibc = new Infrastructure(CpuArchitecture.AMD64, LibcImplementation.GLIBC);
+        Assertions.assertThat(infra_amd64_glibc.getLgbmNativeLibsFolder())
+                .isEqualTo("amd64/glibc/");
+
+        Infrastructure infra_amd64_musl = new Infrastructure(CpuArchitecture.AMD64, LibcImplementation.MUSL);
+        Assertions.assertThat(infra_amd64_musl.getLgbmNativeLibsFolder())
+                .isEqualTo("amd64/musl/");
+    }
+}

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestLibcImplementation.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestLibcImplementation.java
@@ -1,0 +1,43 @@
+/*
+ * The copyright of this file belongs to Feedzai. The file cannot be
+ * reproduced in whole or in part, stored in a retrieval system,
+ * transmitted in any form, or by any means electronic, mechanical,
+ * photocopying, or otherwise, without the prior permission of the owner.
+ *
+ * © 2023 Feedzai, Strictly Confidential
+ */
+package com.feedzai.openml.provider.lightgbm;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+/**
+ * Tests the retrieval of libc implementation.
+ *
+ * @author Renato Azevedo (renato.azevedo@feedzai.com)
+ */
+public class TestLibcImplementation {
+    @Test
+    public void unknownLibcImplementationThrowsException() {
+        Assertions.assertThatThrownBy(() -> LightGBMUtils.getCpuArchitecture("klibc"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void defaultLibcImplementationIsGlibc() {
+        Assertions.assertThat(LightGBMUtils.getLibcImplementation(""))
+                .isEqualTo(LibcImplementation.GLIBC);
+
+        Assertions.assertThat(LightGBMUtils.getLibcImplementation(null))
+                .isEqualTo(LibcImplementation.GLIBC);
+    }
+
+    @Test
+    public void canReadKnownLibcImplementation() {
+        Assertions.assertThat(LightGBMUtils.getLibcImplementation("glibc"))
+                .isEqualTo(LibcImplementation.GLIBC);
+
+        Assertions.assertThat(LightGBMUtils.getLibcImplementation("musl"))
+                .isEqualTo(LibcImplementation.MUSL);
+    }
+}

--- a/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestLibcImplementation.java
+++ b/openml-lightgbm/lightgbm-provider/src/test/java/com/feedzai/openml/provider/lightgbm/TestLibcImplementation.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 public class TestLibcImplementation {
     @Test
     public void unknownLibcImplementationThrowsException() {
-        Assertions.assertThatThrownBy(() -> LightGBMUtils.getCpuArchitecture("klibc"))
+        Assertions.assertThatThrownBy(() -> LightGBMUtils.getLibcImplementation("klibc"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,10 @@
                     </tags>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This commit bumps lightgbm to v0.9.14 and makes it possible to use LGBM on nodes with AMD64 architecture using Alpine.