### PR TITLE
Bump maven-javadoc-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
This upgrade is a try to fix problems in a build that is failing pushing javadoc content.