### PR TITLE
fix(lightgbm): ensuring c++ resources created in swig are released after training

### DIFF
--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainer.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainer.java
@@ -148,33 +148,35 @@ final class LightGBMBinaryClassificationModelTrainer {
         final int numIterations = parseInt(params.get(NUM_ITERATIONS_PARAMETER_NAME));
         logger.debug("LightGBM model trainParams: {}", trainParams);
 
-        final SWIGTrainData swigTrainData = new SWIGTrainData(
+        try (SWIGTrainData swigTrainData = new SWIGTrainData(
                 numFeatures,
                 instancesPerChunk,
                 FairGBMParamParserUtil.isFairnessConstrained(params),
                 sampleWeightColIndex.isPresent()
-        );
-        final SWIGTrainBooster swigTrainBooster = new SWIGTrainBooster();
+        ); SWIGTrainBooster swigTrainBooster = new SWIGTrainBooster()) {
+            /// Create LightGBM dataset
+            final int constraintGroupColIndex = FairGBMParamParserUtil.getConstraintGroupColumnIndex(params, schema)
+                                                                      .orElse(FairGBMParamParserUtil.NO_SPECIFIC);
 
-        /// Create LightGBM dataset
-        final int constraintGroupColIndex = FairGBMParamParserUtil.getConstraintGroupColumnIndex(params, schema).orElse(
-                FairGBMParamParserUtil.NO_SPECIFIC);
-        createTrainDataset(
-                dataset,
-                numFeatures,
-                trainParams,
-                constraintGroupColIndex,
-                sampleWeightColIndex,
-                swigTrainData
-        );
+            createTrainDataset(
+                    dataset,
+                    numFeatures,
+                    trainParams,
+                    constraintGroupColIndex,
+                    sampleWeightColIndex,
+                    swigTrainData
+            );
 
-        /// Create Booster from dataset
-        createBoosterStructure(swigTrainBooster, swigTrainData, trainParams);
-        trainBooster(swigTrainBooster.swigBoosterHandle, numIterations);
+            /// Create Booster from dataset
+            createBoosterStructure(swigTrainBooster, swigTrainData, trainParams);
+            trainBooster(swigTrainBooster.swigBoosterHandle, numIterations);
 
-        /// Save model
-        saveModelFileToDisk(swigTrainBooster.swigBoosterHandle, outputModelFilePath);
-        swigTrainBooster.close(); // Explicitly release C++ resources right away. They're no longer needed.
+            /// Save model
+            saveModelFileToDisk(swigTrainBooster.swigBoosterHandle, outputModelFilePath);
+
+            // Note: By using try-with-resources, the call to both `swigTrainData.close()`
+            //       and `swigTrainBooster.close()` to release C++ resources is guaranteed
+        }
     }
 
     /**

--- a/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainer.java
+++ b/openml-lightgbm/lightgbm-provider/src/main/java/com/feedzai/openml/provider/lightgbm/LightGBMBinaryClassificationModelTrainer.java
@@ -148,12 +148,12 @@ final class LightGBMBinaryClassificationModelTrainer {
         final int numIterations = parseInt(params.get(NUM_ITERATIONS_PARAMETER_NAME));
         logger.debug("LightGBM model trainParams: {}", trainParams);
 
-        try (SWIGTrainData swigTrainData = new SWIGTrainData(
+        try (final SWIGTrainData swigTrainData = new SWIGTrainData(
                 numFeatures,
                 instancesPerChunk,
                 FairGBMParamParserUtil.isFairnessConstrained(params),
                 sampleWeightColIndex.isPresent()
-        ); SWIGTrainBooster swigTrainBooster = new SWIGTrainBooster()) {
+        ); final SWIGTrainBooster swigTrainBooster = new SWIGTrainBooster()) {
             /// Create LightGBM dataset
             final int constraintGroupColIndex = FairGBMParamParserUtil.getConstraintGroupColumnIndex(params, schema)
                                                                       .orElse(FairGBMParamParserUtil.NO_SPECIFIC);


### PR DESCRIPTION
# Summary

This PR addresses a memory leak introduced in #147, by not ensuring the release of all allocated SWIG resources, in particular when training crashes (e.g., when an `IllegalArgumentException` is thrown due to negative sample weights provided). To ensure allocated resources are always released, a try-with-resources is used for the training logic, ensuring the call to `.close()` method for the two resources created - `swigTrainData` and `swigTrainBooster` -, regardless if the training is successful or not