### PR TITLE
Give id token permissions to fix codecov step in master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Give write id-token permissions to build job to avoid auth issues with codecov on master branch.

We need this because we are using OIDC method to authenticate with the plugin (https://github.com/codecov/codecov-action#using-oidc)