### PR TITLE
chore: bump h2o version to 3.46.0.11

### DIFF
--- a/openml-h2o/pom.xml
+++ b/openml-h2o/pom.xml
@@ -30,7 +30,7 @@
     <description>Contains classes and logic related with the import of H2O models.</description>
 
     <properties>
-        <h2o.version>3.36.0.3</h2o.version>
+        <h2o.version>3.46.0.11</h2o.version>
     </properties>
 
     <dependencies>

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/H2OAlgorithm.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/H2OAlgorithm.java
@@ -95,8 +95,6 @@ public enum H2OAlgorithm implements MLAlgorithmEnum {
 
     /**
      * Generalized Linear Models (GLM) estimate regression models for outcomes following exponential distributions.
-     * <p>
-     * We enforce it to always have a family parameter Binomial that causes it to be a classification algorithm.
      */
     GENERALIZED_LINEAR_MODEL(createDescriptor(
             "Generalized Linear Modeling",

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGeneralizedLinearModelUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGeneralizedLinearModelUtils.java
@@ -59,15 +59,16 @@ public final class H2OGeneralizedLinearModelUtils extends AbstractSupervisedH2OA
      */
     public static final Set<ModelParameter> PARAMETERS =
             ParametersBuilderUtil.getParametersFor(GLMParametersV3.class, water.bindings.pojos.GLMParametersV3.class)
-                    .stream()
-                    // Excluded since we "hard-code" to classification.
-                    .filter(modelParam -> !FAMILY.equals(modelParam.getName()))
-                    // H2O UI excludes these in a hard-coded way...so do we.
-                    .filter(modelParameter -> !"tweedie_link_power".equals(modelParameter.getName()) &&
-                            !"tweedie_variance_power".equals(modelParameter.getName()) &&
-                            !"nlambdas".equals(modelParameter.getName()) && !"early_stopping".equals(modelParameter.getName())
-                    )
-                    .collect(Collectors.toSet());
+                             .stream()
+                             // Excluded since we "hard-code" to classification.
+                             .filter(modelParam -> !FAMILY.equals(modelParam.getName()))
+                             // H2O UI excludes these in a hard-coded way...so do we.
+                             .filter(modelParameter -> !"tweedie_link_power".equals(modelParameter.getName()) &&
+                                     !"tweedie_variance_power".equals(modelParameter.getName()) &&
+                                     !"nlambdas".equals(modelParameter.getName()) && !"early_stopping".equals(modelParameter.getName()) &&
+                                     !"influence".equals(modelParameter.getName())
+                             )
+                             .collect(Collectors.toSet());
 
     /**
      * The complete collection of model parameter names of an H2O GLM model.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGeneralizedLinearModelUtils.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/algos/H2OGeneralizedLinearModelUtils.java
@@ -59,16 +59,16 @@ public final class H2OGeneralizedLinearModelUtils extends AbstractSupervisedH2OA
      */
     public static final Set<ModelParameter> PARAMETERS =
             ParametersBuilderUtil.getParametersFor(GLMParametersV3.class, water.bindings.pojos.GLMParametersV3.class)
-                             .stream()
-                             // Excluded since we "hard-code" to classification.
-                             .filter(modelParam -> !FAMILY.equals(modelParam.getName()))
-                             // H2O UI excludes these in a hard-coded way...so do we.
-                             .filter(modelParameter -> !"tweedie_link_power".equals(modelParameter.getName()) &&
-                                     !"tweedie_variance_power".equals(modelParameter.getName()) &&
-                                     !"nlambdas".equals(modelParameter.getName()) && !"early_stopping".equals(modelParameter.getName()) &&
-                                     !"influence".equals(modelParameter.getName())
-                             )
-                             .collect(Collectors.toSet());
+                    .stream()
+                    // Excluded since we "hard-code" to classification.
+                    .filter(modelParam -> !FAMILY.equals(modelParam.getName()))
+                    // H2O UI excludes these in a hard-coded way...so do we.
+                    .filter(modelParameter -> !"tweedie_link_power".equals(modelParameter.getName()) &&
+                            !"tweedie_variance_power".equals(modelParameter.getName()) &&
+                            !"nlambdas".equals(modelParameter.getName()) && !"early_stopping".equals(modelParameter.getName()) &&
+                            !"influence".equals(modelParameter.getName())
+                    )
+                    .collect(Collectors.toSet());
 
     /**
      * The complete collection of model parameter names of an H2O GLM model.

--- a/openml-h2o/src/main/java/com/feedzai/openml/h2o/params/ParametersBuilderUtil.java
+++ b/openml-h2o/src/main/java/com/feedzai/openml/h2o/params/ParametersBuilderUtil.java
@@ -243,7 +243,29 @@ public final class ParametersBuilderUtil {
         if (apiAnnot.values().length > 0) {
             final Set<String> possibleValues = Arrays.stream(apiAnnot.values()).collect(Collectors.toSet());
             final Enum<?> defaultValue = getDefaultChoiceValue(paramsClass, fieldName);
-            paramType = new ChoiceFieldType(possibleValues, defaultValue.name());
+            String defaultValueName = defaultValue != null ? defaultValue.name() : "";
+            if (!possibleValues.contains(defaultValueName)) {
+                final String finalDefaultName = defaultValueName;
+
+                // Check if there is a match
+                final Optional<String> match = possibleValues.stream()
+                                                             .filter(val -> val.equalsIgnoreCase(finalDefaultName))
+                                                             .findFirst();
+
+                if (match.isPresent()) {
+                    defaultValueName = match.get();
+                } else if (!possibleValues.isEmpty()) {
+                    // Fallback to the first allowed choice if the default is missing or null
+                    defaultValueName = possibleValues.iterator().next();
+                    logger.warn(
+                            "Default value name `{}` is not present on possible values set `{}`. Falling back to `{}`",
+                            finalDefaultName,
+                            possibleValues,
+                            defaultValueName
+                    );
+                }
+            }
+            paramType = new ChoiceFieldType(possibleValues, defaultValueName);
 
         } else if (fieldType.equals(String.class)) {
             final String defaultValue = getDefaultStringValue(paramsClass, fieldName);

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
@@ -133,6 +133,8 @@ public final class H2OAlgorithmTestParams {
                 .put("lambda", "1")
                 .put("lambda_search", "true")
                 .put("standardize", "true")
+                 // non_negative does not work with multinomial/ordinal families and GLM
+                 // fails on init if set to true (see https://github.com/h2oai/h2o-3/issues/7055)
                 .put("non_negative", "false")
                 .put("obj_reg", "-1")
                 .put("theta", "1e-10")      // default value

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/H2OAlgorithmTestParams.java
@@ -133,7 +133,7 @@ public final class H2OAlgorithmTestParams {
                 .put("lambda", "1")
                 .put("lambda_search", "true")
                 .put("standardize", "true")
-                .put("non_negative", "true")
+                .put("non_negative", "false")
                 .put("obj_reg", "-1")
                 .put("theta", "1e-10")      // default value
                 .put("HGLM", "false")       // default value

--- a/openml-h2o/src/test/java/com/feedzai/openml/h2o/algos/ParametersTest.java
+++ b/openml-h2o/src/test/java/com/feedzai/openml/h2o/algos/ParametersTest.java
@@ -32,6 +32,8 @@ import com.feedzai.openml.h2o.algos.mocks.PrivateFieldsFieldParameters;
 import com.feedzai.openml.h2o.algos.mocks.RegularParameters;
 import com.feedzai.openml.h2o.params.ParametersBuilderUtil;
 import com.feedzai.openml.provider.descriptor.ModelParameter;
+import com.feedzai.openml.provider.descriptor.fieldtype.ChoiceFieldType;
+
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -176,5 +178,97 @@ public class ParametersTest {
         // addAppender is outdated now
         classLogger.addAppender(listAppender);
         return listAppender;
+    }
+
+    /**
+     * Tests that a case-mismatched enum name is still resolved.
+     */
+    @Test
+    public void choiceFieldCaseMismatchCorrection() {
+        final Set<ModelParameter> parameters = ParametersBuilderUtil.getParametersFor(
+                MockCaseMismatchSchema.class,
+                MockCaseMismatchBinding.class
+        );
+
+        assertThat(parameters).as("The choice parameter descriptor should be resolved successfully").hasSize(1);
+
+        final ModelParameter parameter = parameters.iterator().next();
+
+        assertThat(parameter.getName()).as("The parameter name should match the target field").isEqualTo("dummyField");
+
+        final ChoiceFieldType fieldType = (ChoiceFieldType) parameter.getFieldType();
+
+        assertThat(fieldType.getDefaultValue()).as("The enum 'VALUE_ONE' should match the schema's 'value_one' choice")
+                                               .isEqualTo("value_one");
+    }
+
+    /**
+     * Tests that when an enum field evaluates to null or does not match any valid choices, we fall back to the first
+     * available choice.
+     */
+    @Test
+    public void choiceFieldNullOrMissingFallback() {
+        final ListAppender<ILoggingEvent> listAppender = appendLogger(ParametersBuilderUtil.class);
+
+        final Set<ModelParameter> parameters = ParametersBuilderUtil.getParametersFor(
+                MockFallbackSchema.class,
+                MockFallbackBinding.class
+        );
+
+        assertThat(parameters).as("The parameter descriptor should be built using a fallback strategy").hasSize(1);
+
+        final ModelParameter parameter = parameters.iterator().next();
+
+        assertThat(parameter.getName()).as("The parameter name should match the target field").isEqualTo("dummyField");
+
+        final ChoiceFieldType fieldType = (ChoiceFieldType) parameter.getFieldType();
+
+        assertThat(fieldType.getDefaultValue()).as(
+                "A null value should fall back safely to the first choice in the schema").isEqualTo("value_one");
+
+        final List<ILoggingEvent> loggingList = listAppender.list;
+        assertThat(loggingList).as("A fallback must log an explicit warning").isNotEmpty();
+
+        final ILoggingEvent warningEvent = loggingList.get(0);
+        assertThat(warningEvent.getLevel()).isEqualTo(Level.WARN);
+        assertThat(warningEvent.getMessage()).as("The warning message should detail the fallback replacement")
+                                             .containsIgnoringCase("is not present on possible values set");
+    }
+
+    /**
+     * Dummy enum to simulate parameter choices.
+     */
+    public enum DummyEnum {
+        VALUE_ONE, VALUE_TWO;
+    }
+
+    /**
+     * Schema where the annotation choices are lowercase.
+     */
+    public static class MockCaseMismatchSchema extends water.api.schemas3.ModelParametersSchemaV3 {
+        @water.api.API(help = "Case mismatch", values = {"value_one", "value_two"})
+        public DummyEnum dummyField;
+    }
+
+    /**
+     * Fallback schema to be used when client binding POJO is null.
+     */
+    public static class MockFallbackSchema extends water.api.schemas3.ModelParametersSchemaV3 {
+        @water.api.API(help = "Fallback", values = {"value_one"})
+        public DummyEnum dummyField;
+    }
+
+    /**
+     * Client binding POJO where the runtime field resolves to uppercase.
+     */
+    public static class MockCaseMismatchBinding extends water.bindings.pojos.ModelParametersSchemaV3 {
+        public DummyEnum dummyField = DummyEnum.VALUE_ONE;
+    }
+
+    /**
+     * Client binding POJO where the enum initializes as null.
+     */
+    public static class MockFallbackBinding extends water.bindings.pojos.ModelParametersSchemaV3 {
+        public DummyEnum dummyField = null;
     }
 }


### PR DESCRIPTION
Bumps h2o version to `3.46.0.11` to fix multiple CVEs (CVE-2023-6016, CVE-2023-6038, CVE-2024-10553, CVE-2024-45758, CVE-2024-5986, CVE-2025-5662, CVE-2025-6507).

The bump required adding a fallback mechanism to find the default value of missing API descriptors when upgrading schema bindings. Starting in  `3.40.0.1`, some choice/enum fields were not being initialized with default constants, causing the reflection lookup to return null and failing to statically initialize the core `H2OAlgorithm` registry. This triggered a `ExceptionInInitializerError` during class loading, resulting in a cascade of `NoClassDefFoundError` failures across loading and training test suites when processing uninitialized choice descriptors, so we added a logic of case-insensitive matching with fallback to handle these uninitialized or mismatched enum descriptors.

Also, it required explicitly filtering out regression influence diagnostics (`influence`) as it these can only be specified for gaussian and binomial families (these were introduced in `3.40.0.1` - see https://github.com/h2oai/h2o-3/blob/master/Changes.md#kurka-34001---282023)

Additionally, the MR fixes an issue with `non_negative` constraints in GLM, as these are not allowed for multi-classification datasets (since `3.36.1.1` GLM init fails fast if this is misconfigured - see https://github.com/h2oai/h2o-3/blob/master/Changes.md#zumbo-33611---4132022). 

